### PR TITLE
Fix plugin errors due to #23

### DIFF
--- a/src/com/hpspells/core/HPS.java
+++ b/src/com/hpspells/core/HPS.java
@@ -56,199 +56,208 @@ public class HPS extends JavaPlugin {
     private static CommandMap commandMap;
     private static Collection<HelpTopic> helpTopics = new ArrayList<HelpTopic>();
 
+    /**
+     * State of the Localisation class, if it requires the plugin to disable 
+     * {@code state = false;} otherwise state will always be true
+     */
+    public boolean localeState = true;
+    
     @Override
     public void onEnable() {
         // Instance loading
         PM = new PM(this);
         ConfigurationManager = new ConfigurationManager(this);
         Localisation = new Localisation(this);
-        SpellTargeter = new SpellTargeter(this);
-        SpellManager = new SpellManager(this);
-        Wand = new Wand(this);
-        
-        // Configuration
-        ConfigurationManager.loadConfig();
+        if (localeState) {
+        	SpellTargeter = new SpellTargeter(this);
+            SpellManager = new SpellManager(this);
+            Wand = new Wand(this);
+            
+            // Configuration
+            ConfigurationManager.loadConfig();
 
-        PlayerSpellConfig PSC = (PlayerSpellConfig) ConfigurationManager.getConfig(ConfigurationType.PLAYER_SPELL);
-        Double version = PSC.get().getDouble("VERSION_DO_NOT_EDIT", -1d) == -1d ? null : PSC.get().getDouble("VERSION_DO_NOT_EDIT", -1d);
+            PlayerSpellConfig PSC = (PlayerSpellConfig) ConfigurationManager.getConfig(ConfigurationType.PLAYER_SPELL);
+            Double version = PSC.get().getDouble("VERSION_DO_NOT_EDIT", -1d) == -1d ? null : PSC.get().getDouble("VERSION_DO_NOT_EDIT", -1d);
 
-        if (version == null || version < PlayerSpellConfig.CURRENT_VERSION) {
-            // STORE UPDATES HERE
+            if (version == null || version < PlayerSpellConfig.CURRENT_VERSION) {
+                // STORE UPDATES HERE
 
-            if (version == null) { // Updating from unformatted version to version 1.1
-                PM.log(Level.INFO, Localisation.getTranslation("pscOutOfDate"));
+                if (version == null) { // Updating from unformatted version to version 1.1
+                    PM.log(Level.INFO, Localisation.getTranslation("pscOutOfDate"));
 
-                Map<String, List<String>> newConfig = new HashMap<String, List<String>>(), lists = new HashMap<String, List<String>>();
-                Set<String> css = new HashSet<String>();
+                    Map<String, List<String>> newConfig = new HashMap<String, List<String>>(), lists = new HashMap<String, List<String>>();
+                    Set<String> css = new HashSet<String>();
 
-                for (String s : PSC.get().getKeys(false)) // This seemingly stupid code is to avoid a ConcurrencyModificationException (google it)
-                    css.add(s);
+                    for (String s : PSC.get().getKeys(false)) // This seemingly stupid code is to avoid a ConcurrencyModificationException (google it)
+                        css.add(s);
 
-                for (String s : css)
-                    lists.put(s, PSC.get().getStringList(s));
+                    for (String s : css)
+                        lists.put(s, PSC.get().getStringList(s));
 
-                for (String cs : css) {
-                    List<String> list = new ArrayList<String>();
-                    for (String spellString : PSC.get().getStringList(cs)) {
-                        if (spellString.equals("AlarteAscendare")) {
-                            list.add("Alarte Ascendare");
-                        } else if (spellString.equals("AvadaKedavra")) {
-                            list.add("Avada Kedavra");
-                        } else if (spellString.equals("FiniteIncantatem")) {
-                            list.add("Finite Incantatem");
-                        } else if (spellString.equals("MagnaTonitrus")) {
-                            list.add("Magna Tonitrus");
-                        } else if (spellString.equals("PetrificusTotalus")) {
-                            list.add("Petrificus Totalus");
-                        } else if (spellString.equals("TimeSpell")) {
-                            list.add("Time");
-                        } else if (spellString.equals("TreeSpell")) {
-                            list.add("Tree");
-                        } else if (spellString.equals("WingardiumLeviosa")) {
-                            list.add("Wingardium Leviosa");
-                        } else {
-                            list.add(spellString);
+                    for (String cs : css) {
+                        List<String> list = new ArrayList<String>();
+                        for (String spellString : PSC.get().getStringList(cs)) {
+                            if (spellString.equals("AlarteAscendare")) {
+                                list.add("Alarte Ascendare");
+                            } else if (spellString.equals("AvadaKedavra")) {
+                                list.add("Avada Kedavra");
+                            } else if (spellString.equals("FiniteIncantatem")) {
+                                list.add("Finite Incantatem");
+                            } else if (spellString.equals("MagnaTonitrus")) {
+                                list.add("Magna Tonitrus");
+                            } else if (spellString.equals("PetrificusTotalus")) {
+                                list.add("Petrificus Totalus");
+                            } else if (spellString.equals("TimeSpell")) {
+                                list.add("Time");
+                            } else if (spellString.equals("TreeSpell")) {
+                                list.add("Tree");
+                            } else if (spellString.equals("WingardiumLeviosa")) {
+                                list.add("Wingardium Leviosa");
+                            } else {
+                                list.add(spellString);
+                            }
                         }
+
+                        newConfig.put(cs, list);
                     }
 
-                    newConfig.put(cs, list);
+                    for (Entry<String, List<String>> ent : newConfig.entrySet())
+                        PSC.get().set(ent.getKey(), ent.getValue());
+
+                    PSC.get().set("VERSION_DO_NOT_EDIT", 1.1d);
+                    PSC.save();
+
+                    PM.log(Level.INFO, Localisation.getTranslation("pscUpdated", "1.1"));
                 }
-
-                for (Entry<String, List<String>> ent : newConfig.entrySet())
-                    PSC.get().set(ent.getKey(), ent.getValue());
-
-                PSC.get().set("VERSION_DO_NOT_EDIT", 1.1d);
-                PSC.save();
-
-                PM.log(Level.INFO, Localisation.getTranslation("pscUpdated", "1.1"));
             }
-        }
 
-        // Listeners
-        getServer().getPluginManager().registerEvents(new Listeners(this), this);
-        getServer().getPluginManager().registerEvents(new MetricStatistics(), this);
+            // Listeners
+            getServer().getPluginManager().registerEvents(new Listeners(this), this);
+            getServer().getPluginManager().registerEvents(new MetricStatistics(), this);
 
-        // Hacky command map stuff
-        try {
-            Class<?> craftServer = SVPBypass.getCurrentCBClass("CraftServer");
-            if (craftServer == null)
-                throw new Throwable("Computer says no");
-            Field f = craftServer.getDeclaredField("commandMap");
-            f.setAccessible(true);
-            commandMap = (CommandMap) f.get(getServer());
-        } catch (Throwable e) {
-            PM.log(Level.SEVERE, Localisation.getTranslation("errCommandMap"));
-            PM.debug(e);
-        }
-
-        // Reflections - Commands
-        int commands = 0;
-        try {
-            for (Class<? extends HCommandExecutor> clazz : ReflectionsReplacement.getSubtypesOf(HCommandExecutor.class, "com.hpspells.core.command", getClassLoader(), HCommandExecutor.class)) {
-                if (addHackyCommand(clazz))
-                    commands++;
+            // Hacky command map stuff
+            try {
+                Class<?> craftServer = SVPBypass.getCurrentCBClass("CraftServer");
+                if (craftServer == null)
+                    throw new Throwable("Computer says no");
+                Field f = craftServer.getDeclaredField("commandMap");
+                f.setAccessible(true);
+                commandMap = (CommandMap) f.get(getServer());
+            } catch (Throwable e) {
+                PM.log(Level.SEVERE, Localisation.getTranslation("errCommandMap"));
+                PM.debug(e);
             }
-        } catch (Exception e) {
-            PM.log(Level.WARNING, Localisation.getTranslation("errReflectionsReplacementCmd"));
-            PM.debug(e);
-        }
-        PM.debug(Localisation.getTranslation("dbgRegisteredCoreCommands", commands));
 
-        Bukkit.getHelpMap().addTopic(new IndexHelpTopic("HarryPotterSpells", Localisation.getTranslation("hlpDescription"), "", helpTopics));
-        PM.debug(Localisation.getTranslation("dbgHelpCommandsAdded"));
-
-        // Plugin Metrics
-        try {
-            Metrics metrics = new Metrics(this);
-
-            Graph totalAmountOfSpellsCast = metrics.createGraph("Total Amount of Spells Cast");
-
-            // Total amount of spells cast
-            totalAmountOfSpellsCast.addPlotter(new Plotter("Total") {
-
-                @Override
-                public int getValue() {
-                    return MetricStatistics.getSpellsCast();
+            // Reflections - Commands
+            int commands = 0;
+            try {
+                for (Class<? extends HCommandExecutor> clazz : ReflectionsReplacement.getSubtypesOf(HCommandExecutor.class, "com.hpspells.core.command", getClassLoader(), HCommandExecutor.class)) {
+                    if (addHackyCommand(clazz))
+                        commands++;
                 }
+            } catch (Exception e) {
+                PM.log(Level.WARNING, Localisation.getTranslation("errReflectionsReplacementCmd"));
+                PM.debug(e);
+            }
+            PM.debug(Localisation.getTranslation("dbgRegisteredCoreCommands", commands));
 
-            });
+            Bukkit.getHelpMap().addTopic(new IndexHelpTopic("HarryPotterSpells", Localisation.getTranslation("hlpDescription"), "", helpTopics));
+            PM.debug(Localisation.getTranslation("dbgHelpCommandsAdded"));
 
-            totalAmountOfSpellsCast.addPlotter(new Plotter("Hits") {
+            // Plugin Metrics
+            try {
+                Metrics metrics = new Metrics(this);
 
-                @Override
-                public int getValue() {
-                    return MetricStatistics.getSuccesses();
-                }
+                Graph totalAmountOfSpellsCast = metrics.createGraph("Total Amount of Spells Cast");
 
-            });
-
-            totalAmountOfSpellsCast.addPlotter(new Plotter("Misses") {
-
-                @Override
-                public int getValue() {
-                    return MetricStatistics.getFailures();
-                }
-            });
-
-            // Types of spell cast
-            Graph typesOfSpellCast = metrics.createGraph("Types of Spell Cast");
-
-            for (final Spell spell : SpellManager.getSpells()) {
-                typesOfSpellCast.addPlotter(new Plotter(spell.getName()) {
+                // Total amount of spells cast
+                totalAmountOfSpellsCast.addPlotter(new Plotter("Total") {
 
                     @Override
                     public int getValue() {
-                        return MetricStatistics.getAmountOfTimesCast(spell);
+                        return MetricStatistics.getSpellsCast();
                     }
 
                 });
-            }
 
-            metrics.start();
-        } catch (IOException e) {
-            PM.log(Level.WARNING, Localisation.getTranslation("errPluginMetrics"));
-            PM.debug(e);
-        }
+                totalAmountOfSpellsCast.addPlotter(new Plotter("Hits") {
 
-        // Crafting Changes
-        PM.debug(Localisation.getTranslation("dbgCraftingStart"));
+                    @Override
+                    public int getValue() {
+                        return MetricStatistics.getSuccesses();
+                    }
 
-        if (getConfig().getBoolean("wand.crafting.enabled", true)) {
-            try {
-                ShapedRecipe wandRecipe = new ShapedRecipe(Wand.getLorelessWand());
-                List<String> list = getConfig().getStringList("wand.crafting.recipe");
-                Set<String> ingredients = getConfig().getConfigurationSection("wand.crafting.ingredients").getKeys(false);
+                });
 
-                wandRecipe.shape(list.get(0), list.get(1), list.get(2));
-                for (String string : ingredients)
-                    wandRecipe.setIngredient(string.toCharArray()[0], Material.getMaterial(getConfig().getInt("wand.crafting.ingredients." + string)));
+                totalAmountOfSpellsCast.addPlotter(new Plotter("Misses") {
 
-                getServer().addRecipe(wandRecipe);
-            } catch (Exception e) { // It's surrounded by a try/catch block because we can't let any stupid errors in config disable the plugin.
-                PM.log(Level.INFO, Localisation.getTranslation("errCraftingChanges"));
+                    @Override
+                    public int getValue() {
+                        return MetricStatistics.getFailures();
+                    }
+                });
+
+                // Types of spell cast
+                Graph typesOfSpellCast = metrics.createGraph("Types of Spell Cast");
+
+                for (final Spell spell : SpellManager.getSpells()) {
+                    typesOfSpellCast.addPlotter(new Plotter(spell.getName()) {
+
+                        @Override
+                        public int getValue() {
+                            return MetricStatistics.getAmountOfTimesCast(spell);
+                        }
+
+                    });
+                }
+
+                metrics.start();
+            } catch (IOException e) {
+                PM.log(Level.WARNING, Localisation.getTranslation("errPluginMetrics"));
                 PM.debug(e);
             }
-        }
 
-        if (getConfig().getBoolean("spells-craftable", true)) {
-            for (Spell s : SpellManager.getSpells()) {
-                if (s instanceof Craftable) {
-                    SpellBookRecipeAddEvent e = new SpellBookRecipeAddEvent(((Craftable) s).getCraftingRecipe());
-                    getServer().getPluginManager().callEvent(e);
-                    if (!e.isCancelled())
-                        getServer().addRecipe(e.getRecipe());
+            // Crafting Changes
+            PM.debug(Localisation.getTranslation("dbgCraftingStart"));
+
+            if (getConfig().getBoolean("wand.crafting.enabled", true)) {
+                try {
+                    ShapedRecipe wandRecipe = new ShapedRecipe(Wand.getLorelessWand());
+                    List<String> list = getConfig().getStringList("wand.crafting.recipe");
+                    Set<String> ingredients = getConfig().getConfigurationSection("wand.crafting.ingredients").getKeys(false);
+
+                    wandRecipe.shape(list.get(0), list.get(1), list.get(2));
+                    for (String string : ingredients)
+                        wandRecipe.setIngredient(string.toCharArray()[0], Material.getMaterial(getConfig().getInt("wand.crafting.ingredients." + string)));
+
+                    getServer().addRecipe(wandRecipe);
+                } catch (Exception e) { // It's surrounded by a try/catch block because we can't let any stupid errors in config disable the plugin.
+                    PM.log(Level.INFO, Localisation.getTranslation("errCraftingChanges"));
+                    PM.debug(e);
                 }
             }
+
+            if (getConfig().getBoolean("spells-craftable", true)) {
+                for (Spell s : SpellManager.getSpells()) {
+                    if (s instanceof Craftable) {
+                        SpellBookRecipeAddEvent e = new SpellBookRecipeAddEvent(((Craftable) s).getCraftingRecipe());
+                        getServer().getPluginManager().callEvent(e);
+                        if (!e.isCancelled())
+                            getServer().addRecipe(e.getRecipe());
+                    }
+                }
+            }
+
+            PM.debug(Localisation.getTranslation("dbgCraftingEnd"));
+
+            PM.log(Level.INFO, Localisation.getTranslation("genPluginEnabled"));
         }
-
-        PM.debug(Localisation.getTranslation("dbgCraftingEnd"));
-
-        PM.log(Level.INFO, Localisation.getTranslation("genPluginEnabled"));
     }
 
     @Override
     public void onDisable() {
-        PM.log(Level.INFO, Localisation.getTranslation("genPluginDisabled"));
+    	if (localeState)
+    		PM.log(Level.INFO, Localisation.getTranslation("genPluginDisabled"));
     }
 
     public ClassLoader getHPSClassLoader() {

--- a/src/com/hpspells/core/HPS.java
+++ b/src/com/hpspells/core/HPS.java
@@ -258,6 +258,8 @@ public class HPS extends JavaPlugin {
     public void onDisable() {
     	if (localeState)
     		PM.log(Level.INFO, Localisation.getTranslation("genPluginDisabled"));
+    	else
+    		PM.log(Level.INFO, "Plugin disabled.");
     }
 
     public ClassLoader getHPSClassLoader() {

--- a/src/com/hpspells/core/Listeners.java
+++ b/src/com/hpspells/core/Listeners.java
@@ -137,7 +137,6 @@ public class Listeners implements Listener {
             final Player p = (Player) e.getWhoClicked();
             Bukkit.getScheduler().runTask(HPS, new Runnable() {
 
-                @SuppressWarnings("deprecation")
                 @Override
                 public void run() {
                     p.updateInventory();

--- a/src/com/hpspells/core/Localisation.java
+++ b/src/com/hpspells/core/Localisation.java
@@ -47,8 +47,8 @@ public class Localisation {
     	}
     	this.registerLang(Language.ENGLISH, new File(langFolder, "us-english.properties"));
         this.registerLang(Language.DUTCH, new File(langFolder, "nl-dutch.properties"));
-        this.loadDefaultLang();
-        this.loadLang(Language.getLanuage(HPS.getConfig().getString("language")));
+        if (loadDefaultLang())
+        	this.loadLang(Language.getLanuage(HPS.getConfig().getString("language")));
     }
     
     /**
@@ -60,6 +60,7 @@ public class Localisation {
     	languages.put(language, file);
     	loadedProperties.put(language, new Properties());
     	this.generateFile(file, file.getAbsolutePath().substring(file.getAbsolutePath().lastIndexOf("\\") + 1));
+    	HPS.PM.debug(file.getAbsolutePath());
     }
     
     /**
@@ -79,23 +80,31 @@ public class Localisation {
             HPS.PM.debug(e);
 		} catch (IOException e) {
 			HPS.PM.log(Level.SEVERE, "Could not load any language file. Plugin will not function.", "Disabling plugin...");
+			HPS.PM.debug(e);
+			HPS.localeState = false;
             Bukkit.getServer().getPluginManager().disablePlugin(HPS);
             return;
 		}
     }
     
     /**
-     * Loads the default language of english
+     * Loads the default language of english and returns a boolean
+     * depending on whether the default language was loaded or not.
+     * 
+     * @return true if default language was loaded
      */
-    private void loadDefaultLang() {
+    private boolean loadDefaultLang() {
     	try {
+    		if (!new File(this.langFolder, "us-english.properties").exists()) throw new Exception();
     		defaultLang = loadedProperties.get(Language.ENGLISH);
     		defaultLang.load(new FileInputStream(languages.get(Language.ENGLISH)));
+    		return true;
 		} catch (Exception e) {
 			HPS.PM.log(Level.SEVERE, "Could not load default language. Plugin will not function.", "Disabling plugin...");
             HPS.PM.debug(e);
+            HPS.localeState = false;
             Bukkit.getServer().getPluginManager().disablePlugin(HPS);
-            return;
+            return false;
 		}
     }
     
@@ -184,6 +193,7 @@ public class Localisation {
 				HPS.PM.log(Level.SEVERE, "Error occured while generating language files...", "Unable to close streams");
 				e.printStackTrace();
 			}
+            HPS.PM.log(Level.INFO, "Language file " + lang + " has been sucessfully created.");
         }
         
 //    	if (!file.exists()) {

--- a/src/com/hpspells/core/Localisation.java
+++ b/src/com/hpspells/core/Localisation.java
@@ -169,7 +169,11 @@ public class Localisation {
 
     
     private void generateFile(File file, final String lang) {
-    	InputStream stream = HPS.class.getResourceAsStream("/" + lang);
+    	InputStream stream = HPS.class.getClassLoader().getResourceAsStream(lang);
+//    	HPS.PM.log(Level.INFO, "URL: " + HPS.class.getClassLoader().getResource(lang) == null ? "null" : HPS.class.getClassLoader().getResource(lang).toString());
+//    	HPS.PM.log(Level.INFO, "URL: " + HPS.class.getClassLoader().getResource("/" + lang) == null ? "null" : HPS.class.getClassLoader().getResource("/" + lang).toString()); //null on windows
+//    	HPS.PM.log(Level.INFO, "URL: " + HPS.class.getResource(lang) == null ? "null" : HPS.class.getResource(lang).toString()); //null on windows
+//    	HPS.PM.log(Level.INFO, "URL: " + HPS.class.getResource("/" + lang) == null ? "null" : HPS.class.getResource("/" + lang).toString());
         if (stream == null) {
         	HPS.PM.log(Level.SEVERE, "Could not generate language file " + lang + " Ignore this message if you arent using this language");
         	return;

--- a/src/com/hpspells/core/Wand.java
+++ b/src/com/hpspells/core/Wand.java
@@ -36,10 +36,10 @@ public class Wand {
      * @return {@code true} if the ItemStack is useable as a wand
      */
     public boolean isWand(ItemStack i) {
-    	 if (i.getTypeId() != ((Integer) getConfig("id", 280))) // Item id check
+    	 if (i.getTypeId() != (Integer) getConfig("id", 280)) // Item id check
              return false;
 
-         if (((Boolean) getConfig("lore.enabled", true)) && !i.getItemMeta().getDisplayName().equals((String) getConfig("lore.name", "Wand"))) // Lore name check
+         if ((Boolean) getConfig("lore.enabled", true) && !i.getItemMeta().getDisplayName().equals((String) getConfig("lore.name", "Wand"))) // Lore name check
              return false;
 
          return true;

--- a/src/com/hpspells/core/api/SpellBookRecipe.java
+++ b/src/com/hpspells/core/api/SpellBookRecipe.java
@@ -3,7 +3,6 @@ package com.hpspells.core.api;
 import com.hpspells.core.HPS;
 import com.hpspells.core.spell.Spell;
 import com.hpspells.core.util.MiscUtilities;
-import org.bukkit.Bukkit;
 import org.bukkit.Material;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.Recipe;
@@ -33,7 +32,8 @@ public class SpellBookRecipe implements Recipe {
         this.HPS = instance;
 
         ItemStack stack = new ItemStack(Material.WRITTEN_BOOK);
-        BookMeta meta = (BookMeta) Bukkit.getItemFactory().getItemMeta(Material.WRITTEN_BOOK);
+        
+        BookMeta meta = (BookMeta) stack.getItemMeta();
         meta.setTitle(spell.getName());
         meta.addPage(spell.getDescription());
         meta.setAuthor(getRandomAuthor());


### PR DESCRIPTION
* Plugin now properly disables if #23 happens
  * Add localeState boolean to main class
  * If localeState is false the plugin stops loading and disables
  * localeState is managed by Localisation class
  * localeState is set to false when an Exception that should cause the
  plugin to stop happens
  * Changed loadDefaultLang to boolean so Localisation class can monitor
  outcome
* Add onDisable message
* InputStream test for #23
  * Conclusion:
    * All streams null for ubuntu
    * Unsure if same for all linux/mac
    * Streams 1, 4 work for windows
* Small code cleanup
  * Remove import from SpellBookRecipe
  * Remove deprecation tag for p.updateInventory() in Listeners
  * Remove unneeded brackets in Wand