### PR TITLE
[OfficialBuild] Update to 1.1.5 BETA

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: java
 script: 'mvn test'
 sudo: false
+jdk:
+  - oraclejdk8
 notifications:
   irc: 'irc.esper.net#harrypotterspells'
   skip_join: true

--- a/pom.xml
+++ b/pom.xml
@@ -59,8 +59,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.1</version>
                 <configuration>
-                    <source>1.6</source>
-                    <target>1.6</target>
+                    <source>1.8</source>
+                    <target>1.8</target>
                 </configuration>
             </plugin>
         </plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>HarryPotterSpells</groupId>
     <artifactId>HarryPotterSpells</artifactId>
-    <version>1.1.4 BETA</version>
+    <version>1.1.5 BETA</version>
     <name>HarryPotterSpells</name>
 
     <properties>

--- a/src/com/hpspells/core/HPS.java
+++ b/src/com/hpspells/core/HPS.java
@@ -1,5 +1,6 @@
 package com.hpspells.core;
 
+import java.io.File;
 import java.io.IOException;
 import java.lang.reflect.Field;
 import java.util.ArrayList;
@@ -83,56 +84,58 @@ public class HPS extends JavaPlugin {
 
             PlayerSpellConfig PSC = (PlayerSpellConfig) ConfigurationManager.getConfig(ConfigurationType.PLAYER_SPELL);
             Double version = PSC.get().getDouble("VERSION_DO_NOT_EDIT", -1d) == -1d ? null : PSC.get().getDouble("VERSION_DO_NOT_EDIT", -1d);
+            
+            if (new File(getDataFolder(), "PlayerSpellConfig.yml").exists()) {
+            	if (version == null || version < PlayerSpellConfig.CURRENT_VERSION) {
+                    // STORE UPDATES HERE
 
-            if (version == null || version < PlayerSpellConfig.CURRENT_VERSION) {
-                // STORE UPDATES HERE
+                    if (version == null) { // Updating from unformatted version to version 1.1
+                        PM.log(Level.INFO, Localisation.getTranslation("pscOutOfDate"));
 
-                if (version == null) { // Updating from unformatted version to version 1.1
-                    PM.log(Level.INFO, Localisation.getTranslation("pscOutOfDate"));
+                        Map<String, List<String>> newConfig = new HashMap<String, List<String>>(), lists = new HashMap<String, List<String>>();
+                        Set<String> css = new HashSet<String>();
 
-                    Map<String, List<String>> newConfig = new HashMap<String, List<String>>(), lists = new HashMap<String, List<String>>();
-                    Set<String> css = new HashSet<String>();
+                        for (String s : PSC.get().getKeys(false)) // This seemingly stupid code is to avoid a ConcurrencyModificationException (google it)
+                            css.add(s);
 
-                    for (String s : PSC.get().getKeys(false)) // This seemingly stupid code is to avoid a ConcurrencyModificationException (google it)
-                        css.add(s);
+                        for (String s : css)
+                            lists.put(s, PSC.get().getStringList(s));
 
-                    for (String s : css)
-                        lists.put(s, PSC.get().getStringList(s));
-
-                    for (String cs : css) {
-                        List<String> list = new ArrayList<String>();
-                        for (String spellString : PSC.get().getStringList(cs)) {
-                            if (spellString.equals("AlarteAscendare")) {
-                                list.add("Alarte Ascendare");
-                            } else if (spellString.equals("AvadaKedavra")) {
-                                list.add("Avada Kedavra");
-                            } else if (spellString.equals("FiniteIncantatem")) {
-                                list.add("Finite Incantatem");
-                            } else if (spellString.equals("MagnaTonitrus")) {
-                                list.add("Magna Tonitrus");
-                            } else if (spellString.equals("PetrificusTotalus")) {
-                                list.add("Petrificus Totalus");
-                            } else if (spellString.equals("TimeSpell")) {
-                                list.add("Time");
-                            } else if (spellString.equals("TreeSpell")) {
-                                list.add("Tree");
-                            } else if (spellString.equals("WingardiumLeviosa")) {
-                                list.add("Wingardium Leviosa");
-                            } else {
-                                list.add(spellString);
+                        for (String cs : css) {
+                            List<String> list = new ArrayList<String>();
+                            for (String spellString : PSC.get().getStringList(cs)) {
+                                if (spellString.equals("AlarteAscendare")) {
+                                    list.add("Alarte Ascendare");
+                                } else if (spellString.equals("AvadaKedavra")) {
+                                    list.add("Avada Kedavra");
+                                } else if (spellString.equals("FiniteIncantatem")) {
+                                    list.add("Finite Incantatem");
+                                } else if (spellString.equals("MagnaTonitrus")) {
+                                    list.add("Magna Tonitrus");
+                                } else if (spellString.equals("PetrificusTotalus")) {
+                                    list.add("Petrificus Totalus");
+                                } else if (spellString.equals("TimeSpell")) {
+                                    list.add("Time");
+                                } else if (spellString.equals("TreeSpell")) {
+                                    list.add("Tree");
+                                } else if (spellString.equals("WingardiumLeviosa")) {
+                                    list.add("Wingardium Leviosa");
+                                } else {
+                                    list.add(spellString);
+                                }
                             }
+
+                            newConfig.put(cs, list);
                         }
 
-                        newConfig.put(cs, list);
+                        for (Entry<String, List<String>> ent : newConfig.entrySet())
+                            PSC.get().set(ent.getKey(), ent.getValue());
+
+                        PSC.get().set("VERSION_DO_NOT_EDIT", 1.1d);
+                        PSC.save();
+
+                        PM.log(Level.INFO, Localisation.getTranslation("pscUpdated", "1.1"));
                     }
-
-                    for (Entry<String, List<String>> ent : newConfig.entrySet())
-                        PSC.get().set(ent.getKey(), ent.getValue());
-
-                    PSC.get().set("VERSION_DO_NOT_EDIT", 1.1d);
-                    PSC.save();
-
-                    PM.log(Level.INFO, Localisation.getTranslation("pscUpdated", "1.1"));
                 }
             }
 

--- a/src/com/hpspells/core/HPS.java
+++ b/src/com/hpspells/core/HPS.java
@@ -396,7 +396,7 @@ public class HPS extends JavaPlugin {
         
         @Override
         public List<String> tabComplete(CommandSender sender, String alias, String[] args) throws IllegalArgumentException {
-            List<String> cmdList = new ArrayList<>(Arrays.asList("spellinfo", "spellswitch", "teach", "unteach"));
+            List<String> cmdList = new ArrayList<>(Arrays.asList("spelllist", "teach", "unteach"));
             if (cmdList.contains(this.getName().toLowerCase()) && args.length >= 1 && !HPS.SpellManager.isSpell(args[0])) {
                 List<String> list = new ArrayList<String>();
                 if (args[0] == null) {
@@ -407,6 +407,24 @@ public class HPS extends JavaPlugin {
                 } else {
                     HPS.SpellManager.getSpells().stream()
                     .filter(spell -> spell.getName().toLowerCase().startsWith(args[0]))
+                    .forEach(spell -> {
+                        String spellName = spell.getName().replace(' ', '_');
+                        list.add(spellName);
+                    });
+                }
+                return list;
+            } else if (this.getName().equalsIgnoreCase("spellswitch") && args.length >= 1 && !HPS.SpellManager.isSpell(args[0])) {
+                List<String> list = new ArrayList<String>();
+                if (args[0] == null) {
+                    HPS.SpellManager.getSpells().stream()
+                    .filter(spell -> spell.playerKnows((Player) sender))
+                    .forEach(spell -> {
+                        String spellName = spell.getName().replace(' ', '_');
+                        list.add(spellName);
+                    });
+                } else {
+                    HPS.SpellManager.getSpells().stream()
+                    .filter(spell -> spell.getName().toLowerCase().startsWith(args[0]) && spell.playerKnows((Player) sender))
                     .forEach(spell -> {
                         String spellName = spell.getName().replace(' ', '_');
                         list.add(spellName);

--- a/src/com/hpspells/core/HPS.java
+++ b/src/com/hpspells/core/HPS.java
@@ -52,6 +52,8 @@ import com.hpspells.core.util.ReflectionsReplacement;
 import com.hpspells.core.util.SVPBypass;
 
 public class HPS extends JavaPlugin {
+    public static HPS instance;
+    
     public ConfigurationManager ConfigurationManager;
     public PM PM;
     public SpellManager SpellManager;
@@ -72,6 +74,7 @@ public class HPS extends JavaPlugin {
     
     @Override
     public void onEnable() {
+        instance = this;
         // Instance loading
         PM = new PM(this);
         ConfigurationManager = new ConfigurationManager(this);
@@ -171,6 +174,13 @@ public class HPS extends JavaPlugin {
                 PM.log(Level.WARNING, Localisation.getTranslation("errReflectionsReplacementCmd"));
                 PM.debug(e);
             }
+            
+//            HPSTabCompleter completer = new HPSTabCompleter();
+//            getCommand("spellinfo").setTabCompleter(completer);
+//            getCommand("spellswitch").setTabCompleter(completer);
+//            getCommand("teach").setTabCompleter(completer);
+//            getCommand("unteach").setTabCompleter(completer);
+            
             PM.debug(Localisation.getTranslation("dbgRegisteredCoreCommands", commands));
 
             Bukkit.getHelpMap().addTopic(new IndexHelpTopic("HarryPotterSpells", Localisation.getTranslation("hlpDescription"), "", helpTopics));
@@ -382,6 +392,29 @@ public class HPS extends JavaPlugin {
                     HPS.PM.dependantMessagingTell(sender, ChatColor.RED + HPS.Localisation.getTranslation("cmdUsage", s, getUsage().replace("<command>", commandLabel)));
             }
             return true;
+        }
+        
+        @Override
+        public List<String> tabComplete(CommandSender sender, String alias, String[] args) throws IllegalArgumentException {
+            List<String> cmdList = new ArrayList<>(Arrays.asList("spellinfo", "spellswitch", "teach", "unteach"));
+            if (cmdList.contains(this.getName().toLowerCase()) && args.length >= 1 && !HPS.SpellManager.isSpell(args[0])) {
+                List<String> list = new ArrayList<String>();
+                if (args[0] == null) {
+                    HPS.SpellManager.getSpells().forEach(spell -> {
+                        String spellName = spell.getName().replace(' ', '_');
+                        list.add(spellName);
+                    });
+                } else {
+                    HPS.SpellManager.getSpells().stream()
+                    .filter(spell -> spell.getName().toLowerCase().startsWith(args[0]))
+                    .forEach(spell -> {
+                        String spellName = spell.getName().replace(' ', '_');
+                        list.add(spellName);
+                    });
+                }
+                return list;
+            }
+            return super.tabComplete(sender, alias, args);
         }
 
         /**

--- a/src/com/hpspells/core/Listeners.java
+++ b/src/com/hpspells/core/Listeners.java
@@ -33,7 +33,7 @@ public class Listeners implements Listener {
         this.HPS = instance;
         HPS.getServer().getPluginManager().addPermission(CAST_SPELLS);
     }
-
+    
     @EventHandler
     public void PIE(PlayerInteractEvent e) {
         if (e.getPlayer().hasPermission(CAST_SPELLS) && HPS.Wand.isWand(e.getPlayer().getItemInHand())) {

--- a/src/com/hpspells/core/Listeners.java
+++ b/src/com/hpspells/core/Listeners.java
@@ -1,7 +1,6 @@
 package com.hpspells.core;
 
 import java.util.List;
-import java.util.logging.Level;
 
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;

--- a/src/com/hpspells/core/Wand.java
+++ b/src/com/hpspells/core/Wand.java
@@ -47,7 +47,11 @@ public class Wand {
 
         ItemMeta itemMeta = i.getItemMeta();
 
-        return itemMeta.hasDisplayName() && ChatColor.stripColor(itemMeta.getDisplayName()).equals(ChatColor.stripColor((String) getConfig("name", "Wand")));
+//        HPS.PM.broadcastMessage("Wand name: \n" + itemMeta.getDisplayName());
+//        HPS.PM.broadcastMessage("No Color wand name: \n" + ChatColor.stripColor(itemMeta.getDisplayName()));
+//        HPS.PM.broadcastMessage("No Color config: \n" + ChatColor.stripColor((String) getConfig("lore.name", "Wand")) );
+//        HPS.PM.broadcastMessage("Matching?:" + ChatColor.stripColor(itemMeta.getDisplayName()).equals(ChatColor.stripColor(getName())));
+        return itemMeta.hasDisplayName() && ChatColor.stripColor(itemMeta.getDisplayName()).equals(ChatColor.stripColor(getName()));
         //return new NBTContainerItem(i).getTag(TAG_NAME) != null;
     }
 
@@ -91,7 +95,7 @@ public class Wand {
             meta.setLore(wandCreationEvent.getLore().toStringList());
         }
 
-        meta.setDisplayName(ChatColor.RESET + ChatColor.translateAlternateColorCodes('&', (String) getConfig("lore.name", "Wand")));
+        meta.setDisplayName(ChatColor.RESET + getName());
         wand.setItemMeta(meta);
 
         if (wandCreationEvent.hasEnchantmentEffect()) {
@@ -147,7 +151,7 @@ public class Wand {
         ItemStack wand = new ItemStack(wandMaterial);
         ItemMeta meta = HPS.getServer().getItemFactory().getItemMeta(wandMaterial);
 
-        meta.setDisplayName(ChatColor.RESET + ChatColor.translateAlternateColorCodes('&', (String) getConfig("lore.name", "Wand")));
+        meta.setDisplayName(ChatColor.RESET + getName());
         wand.setItemMeta(meta);
 
         if ((Boolean) getConfig("enchantment-effect", true)) {
@@ -160,6 +164,15 @@ public class Wand {
         }
 
         return wand;
+    }
+    
+    /**
+     * Gets the formatted wand name from the config.
+     * 
+     * @return formatted wand name
+     */
+    public String getName() {
+    	return ChatColor.translateAlternateColorCodes('&', (String) getConfig("lore.name", "Wand"));
     }
 
     public Lore generateLore() {

--- a/src/com/hpspells/core/command/GeneralCommand.java
+++ b/src/com/hpspells/core/command/GeneralCommand.java
@@ -28,10 +28,10 @@ public class GeneralCommand extends HCommandExecutor {
             if (args.length == 1)
                 return false;
             else if (args[1].equalsIgnoreCase("reload")) {
-                HPS.reloadConfig();
-                HPS.ConfigurationManager.reloadConfigAll();
-                HPS.Localisation.load();
-                HPS.PM.dependantMessagingTell(sender, HPS.Localisation.getTranslation("cmdGenConfigReloaded"));
+                if (HPS.onReload())
+                    HPS.PM.dependantMessagingTell(sender, ChatColor.GREEN + HPS.Localisation.getTranslation("cmdGenConfigReloaded"));
+                else 
+                    HPS.PM.dependantMessagingTell(sender, "Config reloaded with errors");
             } else if (args[1].equalsIgnoreCase("edit")) {
                 if (args.length != 5)
                     HPS.PM.dependantMessagingTell(sender, ChatColor.RED + HPS.Localisation.getTranslation("cmdUsage", (sender instanceof Player ? "/" : "") + label, " config edit <key> <new value>"));

--- a/src/com/hpspells/core/command/Unteach.java
+++ b/src/com/hpspells/core/command/Unteach.java
@@ -47,7 +47,7 @@ public class Unteach extends HCommandExecutor {
                     if (newSpell.playerKnows(unteachTo)) {
                         if (forgottenspells == null) {
                             newSpell.unTeach(unteachTo);
-                            forgottenspells = HPS.Localisation.getTranslation("cmdUntForgot", unteachTo.getName()) + newSpell.getName();
+                            forgottenspells = HPS.Localisation.getTranslation("cmdUntForgot", unteachTo.getName()) + " " + newSpell.getName();
                         } else {
                             newSpell.unTeach(unteachTo);
                             forgottenspells = forgottenspells.concat(", " + newSpell.getName());

--- a/src/com/hpspells/core/spell/Bauleo.java
+++ b/src/com/hpspells/core/spell/Bauleo.java
@@ -2,6 +2,7 @@ package com.hpspells.core.spell;
 
 import com.hpspells.core.HPS;
 import com.hpspells.core.spell.Spell.SpellInfo;
+
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.block.Block;
@@ -34,7 +35,7 @@ public class Bauleo extends Spell {
                 for (int z = -(radius); z <= radius; z++) {
                     Block b = new Location(p.getWorld(), loc.getX() + x, loc.getY() + y, loc.getZ() + z).getBlock();
                     if (b.getType() == Material.CHEST) {
-                        chest = (Chest) b;
+                        chest = (Chest) b.getState();
                         break outerLoop;
                     }
                 }

--- a/src/com/hpspells/core/spell/FlameFreezingCharm.java
+++ b/src/com/hpspells/core/spell/FlameFreezingCharm.java
@@ -22,9 +22,9 @@ public class FlameFreezingCharm extends Spell {
 
     @Override
     public boolean cast(Player p) {
-        int duration = (int) getTime("duration", 60);
+        int duration = (int) getTime("duration", 60 * 20);
         p.addPotionEffect(new PotionEffect(PotionEffectType.FIRE_RESISTANCE, duration, 1));
-        HPS.PM.tell(p, "You are now Fire Resistant for " + duration + " seconds.");
+        HPS.PM.tell(p, "You are now Fire Resistant for " + duration / 20 + " seconds.");
         return true;
     }
 

--- a/src/plugin.yml
+++ b/src/plugin.yml
@@ -1,4 +1,4 @@
 name: HarryPotterSpells
 main: com.hpspells.core.HPS
 prefix: "HPS"
-version: 1.1.4 BETA
+version: 1.1.5 BETA


### PR DESCRIPTION
Changelog:
* Tested with Spigot 1.9.2
* Update project to Java 8
* Update travis to build on Java 8
* Fix incorrect message logged for the PlayerSpellConfig
 * If PSC does not exist it will no longer log "PSC out of date", "updating..."
messages
* Fix issue where Wand was not updating with config
 * Fixed issue where wand name wasn't updating when the config was
 * Fixed issue where newly named wands wern't being recognised as wands
* Allow recipes to be reloaded when config reloads
 * Recipes now update when config is reloaded
 * Moved all reloading related stuff to new method HPS.onReload()
* Fix ClassCastException issue with Bauleo, Spell now works again.
* Fix FlameFreezingCharm's duration problem
 * Fixed issue where the default duration was specified in seconds instead of ticks
* [HOT] Add TabComplete support for spells commands
* Fix missing space in message for command Unteach