### PR TITLE
 [OfficialBuild] Update to 1.1.9 BETA

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>HarryPotterSpells</groupId>
     <artifactId>HarryPotterSpells</artifactId>
-    <version>1.1.8 BETA</version>
+    <version>1.1.9 BETA</version>
     <name>HarryPotterSpells</name>
 
     <properties>

--- a/src/com/hpspells/core/HPS.java
+++ b/src/com/hpspells/core/HPS.java
@@ -273,17 +273,10 @@ public class HPS extends JavaPlugin {
     }
     
     public boolean setupCrafting() {
-        List<Recipe> recipeList = new ArrayList<Recipe>();
-        Iterator<Recipe> it = getServer().recipeIterator();
-        while (it.hasNext()) {
-            Recipe recipe = it.next();
-            if (!recipeResults.contains(recipe.getResult())) {
-                recipeList.add(recipe);
-            }
+        if (!recipeResults.isEmpty()) {
+        	recipeResults.clear();
+            getServer().resetRecipes();
         }
-        recipeResults.clear();
-        getServer().clearRecipes();
-        recipeList.stream().forEach(recipe -> getServer().addRecipe(recipe));
     	
         if (getConfig().getBoolean("wand.crafting.enabled", true)) {
             try {

--- a/src/com/hpspells/core/Listeners.java
+++ b/src/com/hpspells/core/Listeners.java
@@ -40,6 +40,11 @@ public class Listeners implements Listener {
     @EventHandler
     public void PIE(PlayerInteractEvent e) {
         HPS.PM.debug("Triggered Once"); // Spellswitch triggered twice when right clicking on a block
+        // MC 1.9 - Offhand introduction. Only listen to main hand events.
+        if (e.getHand() == EquipmentSlot.OFF_HAND) {
+            return;
+        }
+        
         //Below code to stop doors from opening for Colloportus
         if (e.getClickedBlock() != null) {
             Material material = e.getClickedBlock().getType();
@@ -51,20 +56,17 @@ public class Listeners implements Listener {
             }
             if (e.getAction().equals(Action.PHYSICAL)) {
                 if (Colloportus.getPadTypes().contains(material)) {
-                    
+//                    System.out.println("Pressure pad detected");
                 }
             }
             if (e.getAction().equals(Action.RIGHT_CLICK_BLOCK)) {
                 if (material == Material.STONE_BUTTON || material == Material.WOOD_BUTTON) {
-                    
+//                	System.out.println("Button press detected");
                 }
             }
         }
         
         //Normal wand checking code
-        if (e.getHand() == EquipmentSlot.OFF_HAND) {
-            return;
-        }
         if (e.getPlayer().hasPermission(CAST_SPELLS) && HPS.Wand.isWand(e.getPlayer().getInventory().getItemInMainHand())) {
             PlayerSpellConfig psc = (PlayerSpellConfig) HPS.ConfigurationManager.getConfig(ConfigurationType.PLAYER_SPELL);
 

--- a/src/com/hpspells/core/Localisation.java
+++ b/src/com/hpspells/core/Localisation.java
@@ -16,6 +16,7 @@ import java.util.Properties;
 import java.util.logging.Level;
 
 import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
 
 /**
  * A class that manages localisation within the plugin
@@ -182,6 +183,11 @@ public class Localisation {
      * @return the translation or {@code null} if not found
      */
     public String getTranslation(String key, Object... args) {
+    	if (defaultLang.getProperty(key) == null) {
+    		HPS.PM.log(Level.SEVERE, "Translation error occurred. Please contact the developer with the following error:");
+    		HPS.PM.log(Level.SEVERE, "Unable to find property: '" + key + "' for language type: '" + HPS.getConfig().getString("language") + "'");
+    		return ChatColor.RED + "Translation error occurred. Please contact server administrator!";
+    	}
         return activeLang.getProperty(key) == null ? String.format(defaultLang.getProperty(key), args) : String.format(activeLang.getProperty(key), args);
     }
 

--- a/src/com/hpspells/core/command/GeneralCommand.java
+++ b/src/com/hpspells/core/command/GeneralCommand.java
@@ -34,20 +34,34 @@ public class GeneralCommand extends HCommandExecutor {
                     HPS.PM.dependantMessagingTell(sender, "Config reloaded with errors");
             } else if (args[1].equalsIgnoreCase("edit")) {
                 if (args.length != 5)
-                    HPS.PM.dependantMessagingTell(sender, ChatColor.RED + HPS.Localisation.getTranslation("cmdUsage", (sender instanceof Player ? "/" : "") + label, " config edit <key> <new value>"));
+                    HPS.PM.dependantMessagingTell(sender, ChatColor.RED + HPS.Localisation.getTranslation("cmdUsage", (sender instanceof Player ? "/" : "") + label, " config edit <config_type> <key> <new value>"));
                 else {
                     if (args[2].equalsIgnoreCase("default")) {
-                    	HPS.getConfig().set(args[3], args[4]);
-                        HPS.saveConfig();
-                        HPS.PM.dependantMessagingTell(sender, HPS.Localisation.getTranslation("cmdGenConfigUpdated"));
+                    	if (HPS.getConfig().contains(args[3])) {
+                    		HPS.getConfig().set(args[3], args[4]);
+                            HPS.saveConfig();
+                            HPS.PM.dependantMessagingTell(sender, HPS.Localisation.getTranslation("cmdGenConfigUpdated"));
+                    	} else {
+                    		HPS.PM.dependantMessagingTell(sender, ChatColor.RED + HPS.Localisation.getTranslation("cmdUnknownConfigPaths"));
+                    	}
                     } else if (args[2].equalsIgnoreCase("spell")) {
-                    	HPS.getConfig(ConfigurationType.SPELL).get().set(args[3], args[4]);
-                    	HPS.getConfig(ConfigurationType.SPELL).save();
-                        HPS.PM.dependantMessagingTell(sender, HPS.Localisation.getTranslation("cmdGenConfigSpellUpdated"));
+                    	if (HPS.getConfig(ConfigurationType.SPELL).get().contains(args[3])) {
+                    		HPS.getConfig(ConfigurationType.SPELL).get().set(args[3], args[4]);
+                        	HPS.getConfig(ConfigurationType.SPELL).save();
+                            HPS.PM.dependantMessagingTell(sender, HPS.Localisation.getTranslation("cmdGenConfigSpellUpdated"));
+                    	} else {
+                    		HPS.PM.dependantMessagingTell(sender, ChatColor.RED + HPS.Localisation.getTranslation("cmdUnknownConfigPaths"));
+                    	}
                     } else if (args[2].equalsIgnoreCase("cooldown")) {
-                    	HPS.getConfig(ConfigurationType.COOLDOWN).get().set(args[3], args[4]);
-                    	HPS.getConfig(ConfigurationType.COOLDOWN).save();
-                        HPS.PM.dependantMessagingTell(sender, HPS.Localisation.getTranslation("cmdGenConfigCooldownUpdated"));
+                    	if (HPS.getConfig(ConfigurationType.COOLDOWN).get().contains(args[3])) {
+                    		HPS.getConfig(ConfigurationType.COOLDOWN).get().set(args[3], args[4]);
+                        	HPS.getConfig(ConfigurationType.COOLDOWN).save();
+                            HPS.PM.dependantMessagingTell(sender, HPS.Localisation.getTranslation("cmdGenConfigCooldownUpdated"));
+                    	} else {
+                    		HPS.PM.dependantMessagingTell(sender, ChatColor.RED + HPS.Localisation.getTranslation("cmdUnknownConfigPaths"));
+                    	}
+                    } else {
+                    	HPS.PM.dependantMessagingTell(sender, ChatColor.RED + HPS.Localisation.getTranslation("cmdUnknownConfigTypes","Incorrect config type. Possible config types [default, spell, cooldown]"));
                     }
                 }
             }

--- a/src/com/hpspells/core/spell/Alohomora.java
+++ b/src/com/hpspells/core/spell/Alohomora.java
@@ -2,9 +2,11 @@ package com.hpspells.core.spell;
 
 import org.bukkit.Material;
 import org.bukkit.block.Block;
+import org.bukkit.block.BlockFace;
 import org.bukkit.block.BlockState;
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Player;
+import org.bukkit.material.Door;
 import org.bukkit.material.MaterialData;
 import org.bukkit.material.Openable;
 
@@ -36,20 +38,20 @@ public class Alohomora extends Spell {
             @Override
             public void hitBlock(Block block) {
                 if (block.getType() == Material.IRON_DOOR_BLOCK) {
-                    BlockState blockState = block.getState();
-                    MaterialData materialData = blockState.getData();
-                    Openable openable = (Openable) materialData;
+                	// The way minecraft works, top door block doesnt have correct state.
+                	BlockState blockState = block.getState();
+                	if (((Door) blockState.getData()).isTopHalf()) {
+                        blockState = block.getRelative(BlockFace.DOWN).getState();
+                    }
+                	Openable openable = (Openable) blockState.getData();
                     if (openable.isOpen()) {
                         HPS.PM.warn(p, "That door is already open.");
                         return;
                     }
-                    openable.setOpen(true);
-                    blockState.setData(materialData);
-                    blockState.update();
+                    openDoor(block);
                 } else {
                     HPS.PM.warn(p, "You may only use this spell on iron doors.");
                 }
-
             }
 
             @Override
@@ -59,5 +61,18 @@ public class Alohomora extends Spell {
 
         }, 1f, ParticleEffect.SPELL_INSTANT);
         return true;
+    }
+    
+    private void openDoor(Block block) {
+    	BlockState blockState = block.getState();
+    	// The way minecraft works, top door block doesnt have correct state.
+        if (((Door) blockState.getData()).isTopHalf()) {
+            blockState = block.getRelative(BlockFace.DOWN).getState();
+        }
+        MaterialData materialData = blockState.getData();
+        Openable openable = (Openable) materialData;
+        openable.setOpen(true);
+        blockState.setData(materialData);
+        blockState.update();
     }
 }

--- a/src/com/hpspells/core/spell/Alohomora.java
+++ b/src/com/hpspells/core/spell/Alohomora.java
@@ -37,7 +37,13 @@ public class Alohomora extends Spell {
 
             @Override
             public void hitBlock(Block block) {
-                if (block.getType() == Material.IRON_DOOR_BLOCK) {
+            	if (Colloportus.isLockedDoor(block)) {
+                	// Assumes door is closed so unlock and force it open.
+                	if (Colloportus.unlockDoor(block)) {
+                		openDoor(block);
+                		HPS.PM.tell(p, "That door has been unlocked.");
+                	}
+                } else if (block.getType() == Material.IRON_DOOR_BLOCK) {
                 	// The way minecraft works, top door block doesnt have correct state.
                 	BlockState blockState = block.getState();
                 	if (((Door) blockState.getData()).isTopHalf()) {
@@ -50,7 +56,7 @@ public class Alohomora extends Spell {
                     }
                     openDoor(block);
                 } else {
-                    HPS.PM.warn(p, "You may only use this spell on iron doors.");
+                    HPS.PM.warn(p, "You may only use this spell on iron/locked doors.");
                 }
             }
 

--- a/src/com/hpspells/core/util/BlockUtils.java
+++ b/src/com/hpspells/core/util/BlockUtils.java
@@ -1,0 +1,90 @@
+package com.hpspells.core.util;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import org.bukkit.Material;
+import org.bukkit.block.Block;
+import org.bukkit.block.BlockFace;
+
+/**
+ * Class containing block related helpful methods.
+ * 
+ * @author jacklin213
+ *
+ */
+public final class BlockUtils {
+	
+	/**
+     * Find a block that is adjacent to another block given a Material.
+     *
+     * @param block Source block
+     * @param material Material to look for
+     * @param ignore Blocks to ignore
+     * @return Matching block found
+     */
+	public static Block findAdjacentBlock(Block block, Material material, Block... ignore) {
+        BlockFace[] faces = new BlockFace[]{BlockFace.NORTH, BlockFace.SOUTH, BlockFace.EAST, BlockFace.WEST};
+        List<Block> ignoreList = Arrays.asList(ignore);
+
+        for (BlockFace face : faces) {
+            Block adjacentBlock = block.getRelative(face);
+
+            if (adjacentBlock.getType() == material && !ignoreList.contains(adjacentBlock)) {
+                return adjacentBlock;
+            }
+        }
+
+        return null;
+    }
+	
+	/**
+     * Find a block that is adjacent to another block on any of the block's 6 sides given a Material.
+     *
+     * @param block Source block
+     * @param material Material to look for
+     * @param ignore Blocks to ignore
+     * @return Matching block found
+     */
+    public Block findAdjacentBlockOnAllSides(Block block, Material material, Block... ignore) {
+        BlockFace[] faces = new BlockFace[]{BlockFace.NORTH, BlockFace.SOUTH, BlockFace.EAST, BlockFace.WEST, BlockFace.UP, BlockFace.DOWN};
+        List<Block> ignoreList = Arrays.asList(ignore);
+
+        for (BlockFace face : faces) {
+            Block adjacentBlock = block.getRelative(face);
+
+            if (adjacentBlock.getType() == material && !ignoreList.contains(adjacentBlock)) {
+                return adjacentBlock;
+            }
+        }
+
+        return null;
+    }
+	
+    /**
+     * Find all the blocks that are adjacent to another block on any of the block's 6 sides given a Material.
+     * 
+     * @param block Source block
+     * @param material Material to look for
+     * @param ignore Blocks to ignore
+     * @return A list of matching blocks found
+     */
+	public static List<Block> findAllAdjacentBlocks(Block block, Material material, Block... ignore) {
+        BlockFace[] faces = new BlockFace[]{BlockFace.NORTH, BlockFace.SOUTH, BlockFace.EAST, BlockFace.WEST};
+        List<Block> ignoreList = Arrays.asList(ignore);
+        List<Block> adjacentBlockList = new ArrayList<>();
+
+        for (BlockFace face : faces) {
+            Block adjacentBlock = block.getRelative(face);
+
+            if (adjacentBlock.getType() == material && !ignoreList.contains(adjacentBlock)) {
+            	adjacentBlockList.add(adjacentBlock);
+            }
+        }
+
+        return adjacentBlockList;
+    }	
+
+
+}

--- a/src/plugin.yml
+++ b/src/plugin.yml
@@ -1,4 +1,4 @@
 name: HarryPotterSpells
 main: com.hpspells.core.HPS
 prefix: "HPS"
-version: 1.1.8 BETA
+version: 1.1.9 BETA

--- a/src/us-english.properties
+++ b/src/us-english.properties
@@ -21,6 +21,8 @@ cmdNoPermission = You do not have permission to run that command.
 cmdPlayerOnly = You must be a player to use this command.
 cmdPlayerNotFound = That player could not be found.
 cmdPlayerNotSpecified = Please specify a player.
+cmdUnknownConfigPaths = Unknown config path, please double check and try again.
+cmdUnknownConfigTypes = Incorrect config type. Possible config types [default, spell, cooldown]
 
 # Custom Configuration
 ccnCouldNotSave = Could not save config to %s.


### PR DESCRIPTION
Changelog:

Changes:
* Improved command system for editing config files. Now will point out
mistakes in format instead of giving no response to the user during an
error
* Spells:
  * Colloportus - Now supports double doors
  * Alohomora - Now supports double doors and unlocks doors locked by
Colloportus

Bugfixes:
* Fix issue where doors for both Colloportus and Alohomora wouldn't
realize they were open if the top half of the door was targeted.
* Fix lock message appearing twice when right clicking on a Colloportus
locked door
* Fix huge issue where many vanilla recipes weren't working anymore as
well as breaking the Client side recipe book eg) Extending maps, Dying
banners