### PR TITLE
[OfficialBuild] Update to 1.2.3 BETA

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>HarryPotterSpells</groupId>
     <artifactId>HarryPotterSpells</artifactId>
-    <version>1.2.2 BETA</version>
+    <version>1.2.3 BETA</version>
     <name>HarryPotterSpells</name>
 
     <properties>

--- a/src/com/hpspells/core/Localisation.java
+++ b/src/com/hpspells/core/Localisation.java
@@ -72,7 +72,7 @@ public class Localisation {
     	loadedProperties.put(language, new Properties());
     	for (Language lang : languages.keySet())
     		if (!languages.get(lang).exists()) 
-    			this.generateFile(file, file.getAbsolutePath().substring(file.getAbsolutePath().lastIndexOf("\\") + 1));
+    			this.generateFile(file, file.getAbsolutePath().substring(file.getAbsolutePath().lastIndexOf(File.separator) + 1));
     	HPS.PM.debug(file.getAbsolutePath());
     }
     

--- a/src/com/hpspells/core/WandManager.java
+++ b/src/com/hpspells/core/WandManager.java
@@ -11,8 +11,10 @@ import javax.annotation.Nullable;
 import org.bukkit.ChatColor;
 import org.bukkit.Material;
 import org.bukkit.configuration.ConfigurationSection;
+import org.bukkit.enchantments.Enchantment;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.ItemFlag;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
 
@@ -110,16 +112,19 @@ public class WandManager {
         }
 
         meta.setDisplayName(ChatColor.RESET + getName());
-        wand.setItemMeta(meta);
 
         if (wandCreationEvent.hasEnchantmentEffect()) {
             try {
-                wand = MiscUtilities.makeGlow(wand);
+//                wand = MiscUtilities.makeGlow(wand);
+                meta.addEnchant(Enchantment.LURE, 1, true);
+                meta.addItemFlags(ItemFlag.HIDE_ENCHANTS);
             } catch (Exception e) {
                 HPS.PM.debug(HPS.Localisation.getTranslation("errEnchantmentEffect"));
                 HPS.PM.debug(e);
             }
         }
+        
+        wand.setItemMeta(meta);
 
         /*if(owner != null) {
             NBTTagString tag = new NBTTagString();
@@ -166,16 +171,19 @@ public class WandManager {
         ItemMeta meta = HPS.getServer().getItemFactory().getItemMeta(wandMaterial);
 
         meta.setDisplayName(ChatColor.RESET + getName());
-        wand.setItemMeta(meta);
 
         if ((Boolean) getConfig("enchantment-effect", true)) {
             try {
-                wand = MiscUtilities.makeGlow(wand);
+//                wand = MiscUtilities.makeGlow(wand);
+                meta.addEnchant(Enchantment.LURE, 1, true);
+                meta.addItemFlags(ItemFlag.HIDE_ENCHANTS);
             } catch (Exception e) {
                 HPS.PM.debug(HPS.Localisation.getTranslation("errEnchantmentEffect"));
                 HPS.PM.debug(e);
             }
         }
+        
+        wand.setItemMeta(meta);
 
         return wand;
     }

--- a/src/com/hpspells/core/command/GeneralCommand.java
+++ b/src/com/hpspells/core/command/GeneralCommand.java
@@ -12,7 +12,7 @@ import org.bukkit.entity.Player;
 		name = "harrypotterspells", 
 		description = "cmdGenDescription", 
 		aliases = "hps", 
-		usage = "<command> [help]")
+		usage = "<command> [help|reload|config]")
 public class GeneralCommand extends HCommandExecutor {
 	
     public GeneralCommand(HPS instance) {
@@ -26,9 +26,10 @@ public class GeneralCommand extends HCommandExecutor {
             return false;
         
         if (args[0].equalsIgnoreCase("config")) { // Configuration editing/reloading
-            if (args.length == 1)
-                return false;
-            else if (args[1].equalsIgnoreCase("reload")) {
+            if (args.length == 1) {
+                HPS.PM.dependantMessagingTell(sender, ChatColor.RED + HPS.Localisation.getTranslation("cmdUsage", (sender instanceof Player ? "/" : "") + label, " config <reload|edit>"));
+                return true;
+            } else if (args[1].equalsIgnoreCase("reload")) {
                 if (HPS.onReload())
                     HPS.PM.dependantMessagingTell(sender, ChatColor.GREEN + HPS.Localisation.getTranslation("cmdGenConfigReloaded"));
                 else 
@@ -78,6 +79,9 @@ public class GeneralCommand extends HCommandExecutor {
         }
         if (args[0].equalsIgnoreCase("help")) {
         	HPS.PM.dependantMessagingTell(sender, "&6o0=======&c[&eHarryPotterSpells&c]&6========0o");
+        	HPS.PM.dependantMessagingTell(sender, "&b/hps &f- &e" + HPS.Localisation.getTranslation("cmdGenDescription"));
+        	HPS.PM.dependantMessagingTell(sender, "&b/hps reload");
+        	HPS.PM.dependantMessagingTell(sender, "&b/hps config <reload|edit>");
         	HPS.PM.dependantMessagingTell(sender, "&b/spellinfo &f- &e" + HPS.Localisation.getTranslation("cmdSpiDescription"));
         	HPS.PM.dependantMessagingTell(sender, "&b/spelllist &f- &e" + HPS.Localisation.getTranslation("cmdSplDescription"));
         	HPS.PM.dependantMessagingTell(sender, "&b/spellswitch &f- &e" + HPS.Localisation.getTranslation("cmdSpsDescription"));

--- a/src/com/hpspells/core/command/GeneralCommand.java
+++ b/src/com/hpspells/core/command/GeneralCommand.java
@@ -21,6 +21,10 @@ public class GeneralCommand extends HCommandExecutor {
 
     @Override
     public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
+        //If command is just /hps send usage.
+        if (args.length == 0)
+            return false;
+        
         if (args[0].equalsIgnoreCase("config")) { // Configuration editing/reloading
             if (args.length == 1)
                 return false;

--- a/src/com/hpspells/core/command/SpellInfo.java
+++ b/src/com/hpspells/core/command/SpellInfo.java
@@ -17,9 +17,10 @@ public class SpellInfo extends HCommandExecutor {
             return false;
         } else {
             String spell = args[0].replace('_', ' ');
-            if (!HPS.SpellManager.isSpell(spell))
+            if (!HPS.SpellManager.isSpell(spell)) {
                 HPS.PM.dependantMessagingWarn(sender, HPS.Localisation.getTranslation("genSpellNotRecognized"));
-            else
+                return false;
+            } else
                 HPS.PM.dependantMessagingTell(sender, spell + ": " + HPS.SpellManager.getSpell(spell).getDescription());
             return true;
         }

--- a/src/com/hpspells/core/command/SpellList.java
+++ b/src/com/hpspells/core/command/SpellList.java
@@ -15,7 +15,7 @@ import org.bukkit.permissions.PermissionDefault;
 import java.util.SortedSet;
 import java.util.TreeSet;
 
-@CommandInfo(name = "spelllist", description = "cmdSplDescription", usage = "<command> [player]", permissionDefault = "true", aliases = "sl")
+@CommandInfo(name = "spelllist", description = "cmdSplDescription", usage = "<command> [player|me]", permissionDefault = "true", aliases = "sl")
 public class SpellList extends HCommandExecutor {
 
     public SpellList(HPS instance) {
@@ -69,7 +69,7 @@ public class SpellList extends HCommandExecutor {
         if (sender.hasPermission(LIST_OTHERS)) {
             if (Bukkit.getPlayer(args[0]) == null) {
                 HPS.PM.dependantMessagingTell(sender, HPS.Localisation.getTranslation("cmdPlayerNotFound"));
-                return true;
+                return false;
             }
 
             SortedSet<String> spells = new TreeSet<String>(psc.getStringListOrEmpty(args[0]));

--- a/src/com/hpspells/core/command/SpellList.java
+++ b/src/com/hpspells/core/command/SpellList.java
@@ -45,7 +45,7 @@ public class SpellList extends HCommandExecutor {
 
         PlayerSpellConfig psc = (PlayerSpellConfig) HPS.ConfigurationManager.getConfig(ConfigurationType.PLAYER_SPELL);
 
-        if (args[0].equalsIgnoreCase("me")) { // List spells I know
+        if (args[0].equalsIgnoreCase("me") || args[0].equalsIgnoreCase(sender.getName())) { // List spells I know
             if (sender instanceof Player) {
                 SortedSet<String> spells = new TreeSet<String>(psc.getStringListOrEmpty(sender.getName()));
                 if (spells.size() == 0)

--- a/src/com/hpspells/core/command/SpellList.java
+++ b/src/com/hpspells/core/command/SpellList.java
@@ -66,31 +66,28 @@ public class SpellList extends HCommandExecutor {
         }
 
         // List spells someone else knows
-        if (sender instanceof Player) {
-            if (sender.hasPermission(LIST_OTHERS)) {
-                if (Bukkit.getPlayer(args[0]) == null) {
-                    HPS.PM.tell((Player) sender, HPS.Localisation.getTranslation("cmdPlayerNotFound"));
-                    return true;
-                }
+        if (sender.hasPermission(LIST_OTHERS)) {
+            if (Bukkit.getPlayer(args[0]) == null) {
+                HPS.PM.dependantMessagingTell(sender, HPS.Localisation.getTranslation("cmdPlayerNotFound"));
+                return true;
+            }
 
-                SortedSet<String> spells = new TreeSet<String>(psc.getStringListOrEmpty(args[0]));
-                if (spells.size() == 0)
-                    HPS.PM.tell((Player) sender, HPS.Localisation.getTranslation("cmdSplNoneKnown", args[0]));
-                else {
-                    String spellList = null;
-                    for (String spell : spells) {
-                        if (spellList == null)
-                            spellList = (HPS.Localisation.getTranslation("cmdSplPlayerKnows", args[0]) + " ").concat(spell);
-                        else
-                            spellList = spellList.concat(", " + spell);
-                    }
-                    HPS.PM.dependantMessagingTell(sender, spellList + ".");
+            SortedSet<String> spells = new TreeSet<String>(psc.getStringListOrEmpty(args[0]));
+            if (spells.size() == 0)
+                HPS.PM.dependantMessagingTell(sender, HPS.Localisation.getTranslation("cmdSplNoneKnown", args[0]));
+            else {
+                String spellList = null;
+                for (String spell : spells) {
+                    if (spellList == null)
+                        spellList = (HPS.Localisation.getTranslation("cmdSplPlayerKnows", args[0]) + " ").concat(spell);
+                    else
+                        spellList = spellList.concat(", " + spell);
                 }
-            } else
-                HPS.PM.warn((Player) sender, command.getPermissionMessage());
+                HPS.PM.dependantMessagingTell(sender, spellList + ".");
+            }
         } else
-            HPS.PM.dependantMessagingTell(sender, ChatColor.RED + HPS.Localisation.getTranslation("cmdPlayerOnly"));
-
+            HPS.PM.dependantMessagingWarn(sender, command.getPermissionMessage());
+        
         return true;
     }
 }

--- a/src/com/hpspells/core/command/SpellSwitch.java
+++ b/src/com/hpspells/core/command/SpellSwitch.java
@@ -29,6 +29,7 @@ public class SpellSwitch extends HCommandExecutor {
                 String spellName = args[0].replace('_', ' ');
                 if (!HPS.SpellManager.isSpell(spellName)) {
                     HPS.PM.dependantMessagingWarn(player, HPS.Localisation.getTranslation("genSpellNotRecognized"));
+                    return false;
                 } else {
                     Spell spell = HPS.SpellManager.getSpell(spellName);
                     if (!spell.playerKnows(player)) {

--- a/src/com/hpspells/core/command/Teach.java
+++ b/src/com/hpspells/core/command/Teach.java
@@ -35,7 +35,7 @@ public class Teach extends HCommandExecutor {
         if (!HPS.SpellManager.isSpell(args[0].replace('_', ' '))) {
             if (!(args[0].equalsIgnoreCase("all") || args[0].equalsIgnoreCase("*"))) {
                 HPS.PM.dependantMessagingWarn(sender, HPS.Localisation.getTranslation("genSpellNotRecognized"));
-                return true;
+                return false;
             }
         }
 
@@ -47,6 +47,7 @@ public class Teach extends HCommandExecutor {
                 teachTo = (Player) sender;
             } else {
                 HPS.PM.dependantMessagingWarn(sender, HPS.Localisation.getTranslation("cmdPlayerNotSpecified"));
+                return false;
             }
         } else {
             teachTo = Bukkit.getPlayer(args[1]);
@@ -113,6 +114,7 @@ public class Teach extends HCommandExecutor {
             }
         } else {
             HPS.PM.dependantMessagingWarn(sender, HPS.Localisation.getTranslation("cmdPlayerNotFound"));
+            return false;
         }
 
         return true;

--- a/src/com/hpspells/core/command/Teach.java
+++ b/src/com/hpspells/core/command/Teach.java
@@ -57,18 +57,23 @@ public class Teach extends HCommandExecutor {
             boolean teachOnlyKnown = (sender instanceof Player) && sender.hasPermission(teachKnown);
             List<String> senderKnownSpells = ((PlayerSpellConfig) HPS.getConfig(ConfigurationManager.ConfigurationType.PLAYER_SPELL)).getStringListOrEmpty(teachTo.getName());
             
+            HPS.PM.debug("/teach initiated by " + sender + ". teach only known: " + teachOnlyKnown);
+            
             if (args[0].equalsIgnoreCase("all") || args[0].equalsIgnoreCase("*")) {
                 Set<Spell> spells = HPS.SpellManager.getSpells();
                 String learnedSpells = null;
+                boolean hasDeniedSpell = false; //If any spells get denied eg) No perm or Teach only known.
 
                 for (Spell newSpell : spells) {
                     if (!newSpell.playerKnows(teachTo)) {
                     	if (!teachTo.hasPermission(newSpell.getPermission())) {
+                    	    hasDeniedSpell = true;
                     		HPS.PM.dependantMessagingWarn(teachTo, HPS.Localisation.getTranslation("spellUnauthorized"));
                     		continue;
                     	}
 
                         if (teachOnlyKnown && !senderKnownSpells.contains(newSpell.getName())) {
+                            hasDeniedSpell = true;
                             HPS.PM.warn((Player) sender, HPS.Localisation.getTranslation("cmdTeaCantTeach", teachTo.getName(), newSpell.getName()));
                             continue;
                         }
@@ -84,6 +89,7 @@ public class Teach extends HCommandExecutor {
                 }
 
                 if (learnedSpells == null) {
+                    if (hasDeniedSpell) return true; //If no spells taught and spells were denied end the command here.
                     learnedSpells = HPS.Localisation.getTranslation("cmdTeaKnowsAll", teachTo.getName());
                 }
 

--- a/src/com/hpspells/core/command/Teach.java
+++ b/src/com/hpspells/core/command/Teach.java
@@ -8,8 +8,6 @@ import org.bukkit.Bukkit;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
-import org.bukkit.permissions.Permission;
-import org.bukkit.permissions.PermissionDefault;
 
 import java.util.List;
 import java.util.Set;
@@ -18,13 +16,14 @@ import java.util.Set;
 public class Teach extends HCommandExecutor {
     private final HPS HPS;
 
-    private static final Permission teachKnown = new Permission("harrypotterspells.teach.known", "Restricts user to teaching only spells they know", PermissionDefault.FALSE);
+    // No need to register a permission that is not granted by default
+//    private static final Permission teachKnown = new Permission("harrypotterspells.teach.known", "Restricts user to teaching only spells they know", PermissionDefault.FALSE);
 
     public Teach(HPS instance) {
         super(instance);
         HPS = instance;
 
-        instance.getServer().getPluginManager().addPermission(teachKnown);
+//        instance.getServer().getPluginManager().addPermission(teachKnown);
     }
 
     @Override
@@ -54,7 +53,7 @@ public class Teach extends HCommandExecutor {
         }
 
         if (teachTo != null) {
-            boolean teachOnlyKnown = (sender instanceof Player) && sender.hasPermission(teachKnown);
+            boolean teachOnlyKnown = (sender instanceof Player) && sender.hasPermission("harrypotterspells.teach.known") && !sender.isOp();
             List<String> senderKnownSpells = ((PlayerSpellConfig) HPS.getConfig(ConfigurationManager.ConfigurationType.PLAYER_SPELL)).getStringListOrEmpty(sender.getName());
             
             HPS.PM.debug("/teach initiated by " + sender + ". teach only known: " + teachOnlyKnown);

--- a/src/com/hpspells/core/command/Teach.java
+++ b/src/com/hpspells/core/command/Teach.java
@@ -55,7 +55,7 @@ public class Teach extends HCommandExecutor {
 
         if (teachTo != null) {
             boolean teachOnlyKnown = (sender instanceof Player) && sender.hasPermission(teachKnown);
-            List<String> senderKnownSpells = ((PlayerSpellConfig) HPS.getConfig(ConfigurationManager.ConfigurationType.PLAYER_SPELL)).getStringListOrEmpty(teachTo.getName());
+            List<String> senderKnownSpells = ((PlayerSpellConfig) HPS.getConfig(ConfigurationManager.ConfigurationType.PLAYER_SPELL)).getStringListOrEmpty(sender.getName());
             
             HPS.PM.debug("/teach initiated by " + sender + ". teach only known: " + teachOnlyKnown);
             

--- a/src/com/hpspells/core/command/Teach.java
+++ b/src/com/hpspells/core/command/Teach.java
@@ -65,9 +65,9 @@ public class Teach extends HCommandExecutor {
 
                 for (Spell newSpell : spells) {
                     if (!newSpell.playerKnows(teachTo)) {
-                    	if (!teachTo.hasPermission(newSpell.getPermission())) {
+                    	if (!sender.hasPermission(newSpell.getPermission())) {
                     	    hasDeniedSpell = true;
-                    		HPS.PM.dependantMessagingWarn(teachTo, HPS.Localisation.getTranslation("spellUnauthorized"));
+                    		HPS.PM.dependantMessagingWarn(sender, HPS.Localisation.getTranslation("spellUnauthorized") + ": " + newSpell.getName());
                     		continue;
                     	}
 
@@ -94,8 +94,8 @@ public class Teach extends HCommandExecutor {
 
                 HPS.PM.dependantMessagingTell(sender, learnedSpells + ".");
             } else {
-            	if (!teachTo.hasPermission(spell.getPermission())) {
-            		HPS.PM.dependantMessagingWarn(teachTo, HPS.Localisation.getTranslation("spellUnauthorized"));
+            	if (!sender.hasPermission(spell.getPermission())) {
+            		HPS.PM.dependantMessagingWarn(sender, HPS.Localisation.getTranslation("spellUnauthorized")+ ": " + spell.getName());
             		return true;
             	}
 

--- a/src/com/hpspells/core/command/Unteach.java
+++ b/src/com/hpspells/core/command/Unteach.java
@@ -9,7 +9,7 @@ import org.bukkit.entity.Player;
 
 import java.util.Set;
 
-@CommandInfo(name = "unteach", description = "cmdUntDescription", usage = "<command> <spell> [player]")
+@CommandInfo(name = "unteach", description = "cmdUntDescription", usage = "<command> <spell> [player|me]")
 public class Unteach extends HCommandExecutor {
 
     public Unteach(HPS instance) {
@@ -24,7 +24,7 @@ public class Unteach extends HCommandExecutor {
         if (!HPS.SpellManager.isSpell(args[0].replace('_', ' '))) {
             if (!(args[0].equalsIgnoreCase("all") || args[0].equalsIgnoreCase("*"))) {
                 HPS.PM.dependantMessagingWarn(sender, HPS.Localisation.getTranslation("genSpellNotRecognized"));
-                return true;
+                return false;
             }
         }
 
@@ -34,8 +34,10 @@ public class Unteach extends HCommandExecutor {
         if ((args.length == 1) || (args[1].equalsIgnoreCase("me"))) {
             if (sender instanceof Player)
                 unteachTo = (Player) sender;
-            else
+            else {
                 HPS.PM.dependantMessagingWarn(sender, HPS.Localisation.getTranslation("cmdPlayerNotSpecified"));
+                return false;
+            }
         } else
             unteachTo = Bukkit.getPlayer(args[1]);
 
@@ -67,8 +69,10 @@ public class Unteach extends HCommandExecutor {
                 } else
                     HPS.PM.dependantMessagingWarn(sender, HPS.Localisation.getTranslation("cmdUntDoesntKnowOne", unteachTo.getName(), spell.getName()));
             }
-        } else
+        } else {
             HPS.PM.dependantMessagingTell(sender, HPS.Localisation.getTranslation("cmdPlayerNotFound"));
+            return false;
+        }
         return true;
     }
 

--- a/src/com/hpspells/core/command/Unteach.java
+++ b/src/com/hpspells/core/command/Unteach.java
@@ -43,6 +43,11 @@ public class Unteach extends HCommandExecutor {
 
         if (unteachTo != null) {
             if (args[0].equalsIgnoreCase("all") || args[0].equalsIgnoreCase("*")) {
+                if (HPS.SpellManager.getCurrentSpellPosition(unteachTo) == null) {
+                    //Player doesn't know any spells
+                    HPS.PM.dependantMessagingWarn(sender, HPS.Localisation.getTranslation("cmdUntDoesntKnowAll", unteachTo.getName()));
+                    return true;
+                }
                 HPS.SpellManager.setCurrentSpellPosition(unteachTo, 0);
                 Set<Spell> spells = HPS.SpellManager.getSpells();
                 String forgottenspells = null;

--- a/src/com/hpspells/core/command/Wand.java
+++ b/src/com/hpspells/core/command/Wand.java
@@ -13,7 +13,7 @@ import org.bukkit.permissions.PermissionDefault;
 
 import com.hpspells.core.HPS;
 
-@CommandInfo(name = "wand", description = "cmdWanDescription")
+@CommandInfo(name = "wand", description = "cmdWanDescription", usage = "<command> [player|me] [material]")
 public class Wand extends HCommandExecutor {
 
     Permission perm = new Permission("harrypotterspells.wand.others", PermissionDefault.OP);
@@ -73,9 +73,12 @@ public class Wand extends HCommandExecutor {
                     HPS.PM.dependantMessagingTell(sender, HPS.Localisation.getTranslation("cmdWanOffline", ChatColor.GREEN + args[0]));
                 } else {
                     HPS.PM.dependantMessagingWarn(sender, "This player does not exist.");
+                    return false;
                 }
             }
-        } 
+        } else {
+            return false;
+        }
         return true;
     }
     

--- a/src/com/hpspells/core/spell/Bauleo.java
+++ b/src/com/hpspells/core/spell/Bauleo.java
@@ -6,10 +6,11 @@ import com.hpspells.core.spell.Spell.SpellInfo;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.block.Block;
-import org.bukkit.block.Chest;
+import org.bukkit.block.Container;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.Item;
 import org.bukkit.entity.Player;
+import org.bukkit.inventory.Inventory;
 
 @SpellInfo(
         name = "Bauleo",
@@ -26,7 +27,7 @@ public class Bauleo extends Spell {
 
     @Override
     public boolean cast(Player p) {
-        Chest chest = null;
+        Inventory inventory = null;
         Location loc = p.getLocation();
         int radius = 5;
         outerLoop:
@@ -34,21 +35,29 @@ public class Bauleo extends Spell {
             for (int y = -(radius); y <= radius; y++) {
                 for (int z = -(radius); z <= radius; z++) {
                     Block b = new Location(p.getWorld(), loc.getX() + x, loc.getY() + y, loc.getZ() + z).getBlock();
-                    if (b.getType() == Material.CHEST) {
-                        chest = (Chest) b.getState();
+                    if (b.getType() == Material.CHEST || b.getType() == Material.TRAPPED_CHEST || b.getType().name().contains("SHULKER_BOX")) {
+                        //TODO: Find way to implement CHEST_MINECART (Entity) not block.
+                        // Container is the parent class for Chest, ShulkerBox
+                        inventory = ((Container) b.getState()).getInventory();
+                        break outerLoop;
+                    } else if (b.getType() == Material.ENDER_CHEST) {
+                        inventory = p.getEnderChest();
                         break outerLoop;
                     }
                 }
             }
         }
-        if (chest == null) {
+        if (inventory == null) {
             return false;
         }
         for (Entity e : p.getNearbyEntities(5, 5, 5)) {
             if (e instanceof Item) {
                 Item item = (Item) e;
-                chest.getBlockInventory().addItem(item.getItemStack());
-                item.remove();
+                // Only add item into inventory if it is not full
+                if (inventory.firstEmpty() != -1) {
+                    inventory.addItem(item.getItemStack());
+                    item.remove();
+                }
             }
         }
         return true;

--- a/src/com/hpspells/core/spell/Spell.java
+++ b/src/com/hpspells/core/spell/Spell.java
@@ -182,13 +182,15 @@ public abstract class Spell {
         SpellInfo info = this.getClass().getAnnotation(SpellInfo.class);
         if (info == null)
             return 60;
+        
+        String spellName = info.name().toLowerCase().replace(" ", "-");
         if (p.hasPermission(HPS.SpellManager.NO_COOLDOWN_ALL_1) || p.hasPermission(HPS.SpellManager.NO_COOLDOWN_ALL_2)
-                || p.hasPermission("harrypotterspells.nocooldown." + getName().toLowerCase()))
+                || p.hasPermission("harrypotterspells.nocooldown." + spellName))
             return 0;
 
         int cooldown;
-        if (cdConfig.contains("cooldowns." + info.name().toLowerCase().replace(" ", "-")))
-            cooldown = cdConfig.getInt("cooldowns." + info.name().toLowerCase().replace(" ", "-"));
+        if (cdConfig.contains("cooldowns." + spellName))
+            cooldown = cdConfig.getInt("cooldowns." + spellName);
         else
             cooldown = info.cooldown();
 

--- a/src/config.yml
+++ b/src/config.yml
@@ -16,7 +16,7 @@ wand:
   # Generate explosion when /wand is used?
   explosion-effect: false  
   # Should wands have the shiny enchantment effect
-  enchantment-effect : true 
+  enchantment-effect: true 
   lore:
     # The name we should give the wand
     name: '&3Wand' 

--- a/src/plugin.yml
+++ b/src/plugin.yml
@@ -1,5 +1,5 @@
 name: HarryPotterSpells
 main: com.hpspells.core.HPS
 prefix: "HPS"
-version: 1.2.2 BETA
+version: 1.2.3 BETA
 api-version: 1.13


### PR DESCRIPTION
Changelog:

Issues:
* Fix locale generation for UNIX systems by changing hard coded windows file separator "\\" to Java's File.separator as UNIX systems use "/"
* Fix missing wand enchantments
* Fix /hps NullPointerException from missing arg check
* Fix nocooldown perm check for spells that had a space in their names eg) harrypotterspells.nocooldown.homenum-revelio
* Fix /teach * [player] incorrect messaing:
  - /teach * [player] would say the target player knows all the spells even if it errors out for every spell i.e) No perms of teach only known
* Fix issue in /teach where senders known spells list was mistakeny the targets known spell list. 
* Fix issue in /teach where permissions check previously was checking if the receiver had perms and not the sender. Meaning receiver would get the error "You don't have the permission to cast/teach this spell"
* Fix NullPointerException for /unteach * [player] when player doesn't know any spells. Added a check to make sure player knows a/some spells before trying to unteach

Commands:
* HPS: Update usage/help messages
* SpellInfo now displays usage is Spell not recognised
* SpellList:
  - Update command usage
  - Displays usage when player is not found
  - Update so console can see player's SpellList
  - Update so player's username is equivalent to "me"
* SpellSwitch displays usage when spell is not recognised
* Teach:
  - Remove registration of default: false perm harrypotterspells.teach.known
  - Add op check to teachOnlyKnown to prevent ops being blocked as ops inherit all perms
  - Add spell name to end of warning during /teach * so sender knows which spell they do not have permissions for
* Unteach updated usage
* Teach/Unteach displays usage when:
  - Spell not recongised
  - Player not specified (When sender is not a player)
  - Player not found
* Wand:
  - Updated command usage
  - Displays usage when player does not exist
  - Displays usage when arguments do not match

Spells:
* Bauleo
  - In addition to normal Chests, now supports transporting nearby items into TrappedChest, All types of ShulkerBox and Enderchests