### PR TITLE
[OfficialBuild] Update to 1.3.0 BETA

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ To contribute to HarryPotterSpells take a look at our [Contributing file](https:
 * [yebanme](https://github.com/yebanme): Translations - Chinese
 * Park JiHan: Translations - Korean
 * onderek: Translations - Czech
+* EMP: Translations - Norwegian
 
 ## Other Notes ##
 

--- a/README.md
+++ b/README.md
@@ -26,6 +26,14 @@ We are looking for more team members to help make this plugin even more awesome.
 
 To contribute to HarryPotterSpells take a look at our [Contributing file](https://github.com/HarryPotterSpells/HarryPotterSpells/blob/master/CONTRIBUTING.md).
 
+## Other Contributions ##
+* [perseu444](https://github.com/perseu444): Translations - Brazilian Portuguese
+* [Daluse](https://github.com/Daluse): Translations - Spanish
+* [signorhuman](https://github.com/signorhuman): Translations - Italian
+* [milo526](https://github.com/milo526): Translations - Netherlands Dutch
+* [yebanme](https://github.com/yebanme): Translations - Chinese
+* Park JiHan: Translations - Korean
+
 ## Other Notes ##
 
 ### Maven ###

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ To contribute to HarryPotterSpells take a look at our [Contributing file](https:
 * [milo526](https://github.com/milo526): Translations - Netherlands Dutch
 * [yebanme](https://github.com/yebanme): Translations - Chinese
 * Park JiHan: Translations - Korean
+* onderek: Translations - Czech
 
 ## Other Notes ##
 

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ To contribute to HarryPotterSpells take a look at our [Contributing file](https:
 ## Other Contributions ##
 * [perseu444](https://github.com/perseu444): Translations - Brazilian Portuguese
 * [Daluse](https://github.com/Daluse): Translations - Spanish
+* astronomik: Translations - Spanish Update
 * [signorhuman](https://github.com/signorhuman): Translations - Italian
 * [milo526](https://github.com/milo526): Translations - Netherlands Dutch
 * [yebanme](https://github.com/yebanme): Translations - Chinese

--- a/pom.xml
+++ b/pom.xml
@@ -19,9 +19,9 @@
 
     <dependencies>
     	<dependency>
-          	<groupId>org.bukkit</groupId>
-          	<artifactId>bukkit</artifactId>
-         	<version>1.13.2-R0.1-SNAPSHOT</version>
+          	<groupId>org.spigotmc</groupId>
+          	<artifactId>spigot-api</artifactId>
+         	<version>1.20-R0.1-SNAPSHOT</version>
          	<scope>provided</scope>
 		</dependency>
 		<dependency>
@@ -51,8 +51,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.1</version>
                 <configuration>
-                    <source>1.8</source>
-                    <target>1.8</target>
+                    <source>17</source>
+                    <target>17</target>
                 </configuration>
             </plugin>
         </plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>HarryPotterSpells</groupId>
     <artifactId>HarryPotterSpells</artifactId>
-    <version>1.2.4 BETA</version>
+    <version>1.3.0 BETA</version>
     <name>HarryPotterSpells</name>
 
     <properties>

--- a/src/com/hpspells/core/HPS.java
+++ b/src/com/hpspells/core/HPS.java
@@ -265,9 +265,9 @@ public class HPS extends JavaPlugin {
                     wandRecipe.setIngredient(string.toCharArray()[0], Material.matchMaterial(getConfig().getString("wand.crafting.ingredients." + string)));
                 }
 
+                PM.log(Level.INFO, "Adding recipe for wand");
                 recipeResults.add(wandRecipe.getResult());
                 getServer().addRecipe(wandRecipe);
-                return true;
             } catch (NullPointerException e) { // It's surrounded by a try/catch block because we can't let any stupid errors in config disable the plugin.
                 for (Player player : Bukkit.getOnlinePlayers()) {
                     if (player.isOp()) {
@@ -286,16 +286,24 @@ public class HPS extends JavaPlugin {
         }
 
         if (getConfig().getBoolean("spells-craftable", true)) {
+            PM.debug("spells-craftable config set to true, looking for spell recipes to register");
+            Integer craftableCount = 0;
+            Integer registeredCount = 0;
             for (Spell s : SpellManager.getSpells()) {
                 if (s instanceof Craftable) {
+                    craftableCount++;
+                    PM.debug("Triggering SpellBookRecipeAddEvent for spell: " + s.getName());
                     SpellBookRecipeAddEvent e = new SpellBookRecipeAddEvent(((Craftable) s).getCraftingRecipe());
                     getServer().getPluginManager().callEvent(e);
                     if (!e.isCancelled()) {
+                        PM.debug("Adding recipe for craftable spell: " + s.getName());
                         recipeResults.add(e.getRecipe().getResult());
                         getServer().addRecipe(e.getRecipe());
+                        registeredCount++;
                     }
                 }
             }
+            PM.log(Level.INFO, String.format("Registered %d/%d craftable spell recipes!", craftableCount, registeredCount));
         }
         return true;
     }

--- a/src/com/hpspells/core/HPS.java
+++ b/src/com/hpspells/core/HPS.java
@@ -46,7 +46,6 @@ import com.hpspells.core.spell.SpellManager;
 import com.hpspells.core.spell.interfaces.Craftable;
 import com.hpspells.core.util.MetricStatistics;
 import com.hpspells.core.util.ReflectionsReplacement;
-import com.hpspells.core.util.SVPBypass;
 
 public class HPS extends JavaPlugin {
     public static HPS instance;
@@ -147,12 +146,9 @@ public class HPS extends JavaPlugin {
             getServer().getPluginManager().registerEvents(new Listeners(this), this);
             getServer().getPluginManager().registerEvents(new MetricStatistics(), this);
 
-            // Hacky command map stuff
+            // Hacky command map stuff - Adding commands without using plugin.yml
             try {
-                Class<?> craftServer = SVPBypass.getCurrentCBClass("CraftServer");
-                if (craftServer == null)
-                    throw new Throwable("Computer says no");
-                Field f = craftServer.getDeclaredField("commandMap");
+                Field f = getServer().getClass().getDeclaredField("commandMap");
                 f.setAccessible(true);
                 commandMap = (CommandMap) f.get(getServer());
             } catch (Throwable e) {

--- a/src/com/hpspells/core/HPS.java
+++ b/src/com/hpspells/core/HPS.java
@@ -180,7 +180,7 @@ public class HPS extends JavaPlugin {
             PM.debug(Localisation.getTranslation("dbgHelpCommandsAdded"));
 
             // Plugin Metrics
-            setupCharts(new Metrics(this));
+            setupCharts(new Metrics(this, 2858));
 
             // Crafting Changes
             PM.debug(Localisation.getTranslation("dbgCraftingStart"));

--- a/src/com/hpspells/core/HPS.java
+++ b/src/com/hpspells/core/HPS.java
@@ -245,7 +245,7 @@ public class HPS extends JavaPlugin {
             } ));
             
             // Language used
-            metrics.addCustomChart(new Metrics.SimplePie("Language", () -> Language.getLanuage(getConfig().getString("language")).toString()));
+            metrics.addCustomChart(new Metrics.SimplePie("Language", () -> Language.getLanguage(getConfig().getString("language")).toString()));
         } catch (Exception e) {
             PM.log(Level.WARNING, Localisation.getTranslation("errPluginMetrics"));
             PM.debug(e);

--- a/src/com/hpspells/core/Listeners.java
+++ b/src/com/hpspells/core/Listeners.java
@@ -34,12 +34,18 @@ public class Listeners implements Listener {
     
     private List<Material> buttonTypeList = new ArrayList<>(Arrays.asList(
     		Material.ACACIA_BUTTON,
+    		Material.BAMBOO_BUTTON,
     		Material.BIRCH_BUTTON,
+    		Material.CHERRY_BUTTON,
+    		Material.CRIMSON_BUTTON,
     		Material.DARK_OAK_BUTTON,
     		Material.JUNGLE_BUTTON,
+    		Material.MANGROVE_BUTTON,
     		Material.OAK_BUTTON,
+    		Material.POLISHED_BLACKSTONE_BUTTON,
     		Material.SPRUCE_BUTTON,
-    		Material.STONE_BUTTON
+    		Material.STONE_BUTTON,
+    		Material.WARPED_BUTTON
     ));
 
     public static final Permission CAST_SPELLS = new Permission("harrypotterspells.cast", PermissionDefault.OP);
@@ -51,6 +57,7 @@ public class Listeners implements Listener {
     
     @EventHandler
     public void PIE(PlayerInteractEvent e) {
+    	for(String world : HPS.getConfig().getStringList("disabledWorlds")) if(e.getPlayer().getWorld().getName().toLowerCase().equals(world.toLowerCase())) return;
         HPS.PM.debug("Triggered Once"); // Spellswitch triggered twice when right clicking on a block
         // MC 1.9 - Offhand introduction. Only listen to main hand events.
         if (e.getHand() == EquipmentSlot.OFF_HAND) {
@@ -154,6 +161,7 @@ public class Listeners implements Listener {
 
     @EventHandler
     public void PIEE(PlayerInteractEntityEvent e) {
+    	for(String world : HPS.getConfig().getStringList("disabledWorlds")) if(e.getPlayer().getWorld().getName().toLowerCase().equals(world.toLowerCase())) return;
         HPS.PM.debug("Fired PlayerInteractEntityEvent");
         if (e.getPlayer().hasPermission(CAST_SPELLS) && HPS.WandManager.isWand(e.getPlayer().getInventory().getItemInMainHand())) {
             PlayerSpellConfig psc = (PlayerSpellConfig) HPS.ConfigurationManager.getConfig(ConfigurationType.PLAYER_SPELL);
@@ -190,6 +198,7 @@ public class Listeners implements Listener {
 
     @EventHandler
     public void onPlayerChat(final AsyncPlayerChatEvent e) {
+    	for(String world : HPS.getConfig().getStringList("disabledWorlds")) if(e.getPlayer().getWorld().getName().toLowerCase().equals(world.toLowerCase())) return;
         if (HPS.getConfig().getBoolean("spell-castable-with-chat")) {
             if (HPS.SpellManager.isSpell(e.getMessage().substring(0, e.getMessage().length() - 1))) {
                 Bukkit.getScheduler().runTask(HPS, new Runnable() {
@@ -208,7 +217,7 @@ public class Listeners implements Listener {
     @EventHandler
     public void onPlayerCraft(CraftItemEvent e) {
         if (HPS.WandManager.isWand(e.getRecipe().getResult())) {
-            e.setCurrentItem(HPS.WandManager.getWand((Player) e.getWhoClicked()));
+        	e.setCurrentItem(HPS.WandManager.getWand((Player) e.getWhoClicked()));
             final Player p = (Player) e.getWhoClicked();
             Bukkit.getScheduler().runTask(HPS, new Runnable() {
 
@@ -223,6 +232,7 @@ public class Listeners implements Listener {
     
     @EventHandler(priority=EventPriority.LOWEST)
     public void onSpellCast(SpellPreCastEvent e) {
+    	for(String world : HPS.getConfig().getStringList("disabledWorlds")) if(e.getCaster().getWorld().getName().toLowerCase().equals(world.toLowerCase())) return;
     	if (!e.getCaster().hasPermission(e.getSpell().getPermission())) {
     		e.setCancelled(true);
     		HPS.PM.warn(e.getCaster(), HPS.Localisation.getTranslation("spellUnauthorized"));

--- a/src/com/hpspells/core/Localisation.java
+++ b/src/com/hpspells/core/Localisation.java
@@ -59,8 +59,9 @@ public class Localisation {
         this.registerLang(Language.ITALIAN, new File(langFolder, "it-italian.properties"));
         this.registerLang(Language.CHINESE, new File(langFolder, "zh-chinese.properties"));
 		this.registerLang(Language.PORTUGUESE, new File(langFolder, "br-portuguese.properties"));
+		this.registerLang(Language.KOREAN, new File(langFolder, "kr-korean.properties"));
         if (loadDefaultLang())
-        	this.loadLang(Language.getLanuage(HPS.getConfig().getString("language")));
+        	this.loadLang(Language.getLanguage(HPS.getConfig().getString("language")));
     }
     
     /**
@@ -258,14 +259,15 @@ public class Localisation {
     	SPANISH,
     	ITALIAN,
     	CHINESE,
-		PORTUGUESE;
-    	
+    	PORTUGUESE,
+    	KOREAN;
+
     	/**
     	 * Gets the language from its configuration name
     	 * @param name The configuration language name
     	 * @return Enum of language. ENGLISH if no matches found
     	 */
-    	public static Language getLanuage(String name) {
+    	public static Language getLanguage(String name) {
     		if (name.equalsIgnoreCase("nl-dutch")) {
     			return DUTCH;
     		} else if (name.equalsIgnoreCase("de-german")) {
@@ -278,6 +280,8 @@ public class Localisation {
                 return CHINESE;
             } else if (name.equalsIgnoreCase("br-portuguese")) {
 				return PORTUGUESE;
+			} else if (name.equalsIgnoreCase("kr-korean")) {
+				return KOREAN;
 			}
     		return ENGLISH;
     	}

--- a/src/com/hpspells/core/Localisation.java
+++ b/src/com/hpspells/core/Localisation.java
@@ -60,6 +60,7 @@ public class Localisation {
         this.registerLang(Language.CHINESE, new File(langFolder, "zh-chinese.properties"));
 		this.registerLang(Language.PORTUGUESE, new File(langFolder, "br-portuguese.properties"));
 		this.registerLang(Language.KOREAN, new File(langFolder, "kr-korean.properties"));
+		this.registerLang(Language.CZECH, new File(langFolder, "cz-czech.properties"));
         if (loadDefaultLang())
         	this.loadLang(Language.getLanguage(HPS.getConfig().getString("language")));
     }
@@ -260,7 +261,8 @@ public class Localisation {
     	ITALIAN,
     	CHINESE,
     	PORTUGUESE,
-    	KOREAN;
+    	KOREAN,
+    	CZECH;
 
     	/**
     	 * Gets the language from its configuration name
@@ -282,6 +284,8 @@ public class Localisation {
 				return PORTUGUESE;
 			} else if (name.equalsIgnoreCase("kr-korean")) {
 				return KOREAN;
+			} else if (name.equalsIgnoreCase("cz-czech")) {
+				return CZECH;
 			}
     		return ENGLISH;
     	}

--- a/src/com/hpspells/core/Localisation.java
+++ b/src/com/hpspells/core/Localisation.java
@@ -61,6 +61,7 @@ public class Localisation {
 		this.registerLang(Language.PORTUGUESE, new File(langFolder, "br-portuguese.properties"));
 		this.registerLang(Language.KOREAN, new File(langFolder, "kr-korean.properties"));
 		this.registerLang(Language.CZECH, new File(langFolder, "cz-czech.properties"));
+		this.registerLang(Language.NORWEGIAN, new File(langFolder, "no-norwegian.properties"));
         if (loadDefaultLang())
         	this.loadLang(Language.getLanguage(HPS.getConfig().getString("language")));
     }
@@ -262,7 +263,8 @@ public class Localisation {
     	CHINESE,
     	PORTUGUESE,
     	KOREAN,
-    	CZECH;
+    	CZECH,
+    	NORWEGIAN;
 
     	/**
     	 * Gets the language from its configuration name
@@ -286,6 +288,8 @@ public class Localisation {
 				return KOREAN;
 			} else if (name.equalsIgnoreCase("cz-czech")) {
 				return CZECH;
+			} else if (name.equalsIgnoreCase("no-norwegian")) {
+				return NORWEGIAN;
 			}
     		return ENGLISH;
     	}

--- a/src/com/hpspells/core/Metrics.java
+++ b/src/com/hpspells/core/Metrics.java
@@ -1,23 +1,44 @@
+/*
+ * This Metrics class was auto-generated and can be copied into your project if you are
+ * not using a build tool like Gradle or Maven for dependency management.
+ *
+ * IMPORTANT: You are not allowed to modify this class, except changing the package.
+ *
+ * Disallowed modifications include but are not limited to:
+ *  - Remove the option for users to opt-out
+ *  - Change the frequency for data submission
+ *  - Obfuscate the code (every obfuscator should allow you to make an exception for specific files)
+ *  - Reformat the code (if you use a linter, add an exception)
+ *
+ * Violations will result in a ban of your plugin and account from bStats.
+ */
 package com.hpspells.core;
 
+import java.io.BufferedReader;
 import java.io.ByteArrayOutputStream;
 import java.io.DataOutputStream;
 import java.io.File;
 import java.io.IOException;
-import java.lang.reflect.InvocationTargetException;
+import java.io.InputStreamReader;
 import java.lang.reflect.Method;
-import java.net.MalformedURLException;
 import java.net.URL;
-import java.util.ArrayList;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
 import java.util.Collection;
-import java.util.List;
+import java.util.HashSet;
 import java.util.Map;
-import java.util.Scanner;
-import java.util.Timer;
-import java.util.TimerTask;
+import java.util.Objects;
+import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.Callable;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+import java.util.function.BiConsumer;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
 import java.util.logging.Level;
+import java.util.stream.Collectors;
 import java.util.zip.GZIPOutputStream;
 
 import javax.net.ssl.HttpsURLConnection;
@@ -25,668 +46,862 @@ import javax.net.ssl.HttpsURLConnection;
 import org.bukkit.Bukkit;
 import org.bukkit.configuration.file.YamlConfiguration;
 import org.bukkit.entity.Player;
-import org.bukkit.plugin.RegisteredServiceProvider;
-import org.bukkit.plugin.ServicePriority;
-import org.bukkit.plugin.java.JavaPlugin;
-import org.json.simple.JSONArray;
-import org.json.simple.JSONObject;
+import org.bukkit.plugin.Plugin;
 
-/**
- * bStats collects some data for plugin authors.
- *
- * Check out https://bStats.org/ to learn more about bStats!
- */
 public class Metrics {
 
-    static {
-        // You can use the property to disable the check in your test environment
-        if (System.getProperty("bstats.relocatecheck") == null || !System.getProperty("bstats.relocatecheck").equals("false")) {
-            // Maven's Relocate is clever and changes strings, too. So we have to use this little "trick" ... :D
-            final String defaultPackage = new String(
-                    new byte[]{'o', 'r', 'g', '.', 'b', 's', 't', 'a', 't', 's', '.', 'b', 'u', 'k', 'k', 'i', 't'});
-            final String examplePackage = new String(new byte[]{'y', 'o', 'u', 'r', '.', 'p', 'a', 'c', 'k', 'a', 'g', 'e'});
-            // We want to make sure nobody just copy & pastes the example and use the wrong package names
-            if (Metrics.class.getPackage().getName().equals(defaultPackage) || Metrics.class.getPackage().getName().equals(examplePackage)) {
-                throw new IllegalStateException("bStats Metrics class has not been relocated correctly!");
+  private final Plugin plugin;
+
+  private final MetricsBase metricsBase;
+
+  /**
+   * Creates a new Metrics instance.
+   *
+   * @param plugin Your plugin instance.
+   * @param serviceId The id of the service. It can be found at <a
+   *     href="https://bstats.org/what-is-my-plugin-id">What is my plugin id?</a>
+   */
+  public Metrics(Plugin plugin, int serviceId) {
+    this.plugin = plugin;
+    // Get the config file
+    File bStatsFolder = new File(plugin.getDataFolder().getParentFile(), "bStats");
+    File configFile = new File(bStatsFolder, "config.yml");
+    YamlConfiguration config = YamlConfiguration.loadConfiguration(configFile);
+    if (!config.isSet("serverUuid")) {
+      config.addDefault("enabled", true);
+      config.addDefault("serverUuid", UUID.randomUUID().toString());
+      config.addDefault("logFailedRequests", false);
+      config.addDefault("logSentData", false);
+      config.addDefault("logResponseStatusText", false);
+      // Inform the server owners about bStats
+      config
+          .options()
+          .header(
+              "bStats (https://bStats.org) collects some basic information for plugin authors, like how\n"
+                  + "many people use their plugin and their total player count. It's recommended to keep bStats\n"
+                  + "enabled, but if you're not comfortable with this, you can turn this setting off. There is no\n"
+                  + "performance penalty associated with having metrics enabled, and data sent to bStats is fully\n"
+                  + "anonymous.")
+          .copyDefaults(true);
+      try {
+        config.save(configFile);
+      } catch (IOException ignored) {
+      }
+    }
+    // Load the data
+    boolean enabled = config.getBoolean("enabled", true);
+    String serverUUID = config.getString("serverUuid");
+    boolean logErrors = config.getBoolean("logFailedRequests", false);
+    boolean logSentData = config.getBoolean("logSentData", false);
+    boolean logResponseStatusText = config.getBoolean("logResponseStatusText", false);
+    boolean isFolia = false;
+    try {
+      isFolia = Class.forName("io.papermc.paper.threadedregions.RegionizedServer") != null;
+    } catch (Exception e) {
+    }
+    metricsBase =
+        new // See https://github.com/Bastian/bstats-metrics/pull/126
+        // See https://github.com/Bastian/bstats-metrics/pull/126
+        // See https://github.com/Bastian/bstats-metrics/pull/126
+        // See https://github.com/Bastian/bstats-metrics/pull/126
+        // See https://github.com/Bastian/bstats-metrics/pull/126
+        // See https://github.com/Bastian/bstats-metrics/pull/126
+        // See https://github.com/Bastian/bstats-metrics/pull/126
+        MetricsBase(
+            "bukkit",
+            serverUUID,
+            serviceId,
+            enabled,
+            this::appendPlatformData,
+            this::appendServiceData,
+            isFolia
+                ? null
+                : submitDataTask -> Bukkit.getScheduler().runTask(plugin, submitDataTask),
+            plugin::isEnabled,
+            (message, error) -> this.plugin.getLogger().log(Level.WARNING, message, error),
+            (message) -> this.plugin.getLogger().log(Level.INFO, message),
+            logErrors,
+            logSentData,
+            logResponseStatusText,
+            false);
+  }
+
+  /** Shuts down the underlying scheduler service. */
+  public void shutdown() {
+    metricsBase.shutdown();
+  }
+
+  /**
+   * Adds a custom chart.
+   *
+   * @param chart The chart to add.
+   */
+  public void addCustomChart(CustomChart chart) {
+    metricsBase.addCustomChart(chart);
+  }
+
+  private void appendPlatformData(JsonObjectBuilder builder) {
+    builder.appendField("playerAmount", getPlayerAmount());
+    builder.appendField("onlineMode", Bukkit.getOnlineMode() ? 1 : 0);
+    builder.appendField("bukkitVersion", Bukkit.getVersion());
+    builder.appendField("bukkitName", Bukkit.getName());
+    builder.appendField("javaVersion", System.getProperty("java.version"));
+    builder.appendField("osName", System.getProperty("os.name"));
+    builder.appendField("osArch", System.getProperty("os.arch"));
+    builder.appendField("osVersion", System.getProperty("os.version"));
+    builder.appendField("coreCount", Runtime.getRuntime().availableProcessors());
+  }
+
+  private void appendServiceData(JsonObjectBuilder builder) {
+    builder.appendField("pluginVersion", plugin.getDescription().getVersion());
+  }
+
+  private int getPlayerAmount() {
+    try {
+      // Around MC 1.8 the return type was changed from an array to a collection,
+      // This fixes java.lang.NoSuchMethodError:
+      // org.bukkit.Bukkit.getOnlinePlayers()Ljava/util/Collection;
+      Method onlinePlayersMethod = Class.forName("org.bukkit.Server").getMethod("getOnlinePlayers");
+      return onlinePlayersMethod.getReturnType().equals(Collection.class)
+          ? ((Collection<?>) onlinePlayersMethod.invoke(Bukkit.getServer())).size()
+          : ((Player[]) onlinePlayersMethod.invoke(Bukkit.getServer())).length;
+    } catch (Exception e) {
+      // Just use the new method if the reflection failed
+      return Bukkit.getOnlinePlayers().size();
+    }
+  }
+
+  public static class MetricsBase {
+
+    /** The version of the Metrics class. */
+    public static final String METRICS_VERSION = "3.1.0";
+
+    private static final String REPORT_URL = "https://bStats.org/api/v2/data/%s";
+
+    private final ScheduledExecutorService scheduler;
+
+    private final String platform;
+
+    private final String serverUuid;
+
+    private final int serviceId;
+
+    private final Consumer<JsonObjectBuilder> appendPlatformDataConsumer;
+
+    private final Consumer<JsonObjectBuilder> appendServiceDataConsumer;
+
+    private final Consumer<Runnable> submitTaskConsumer;
+
+    private final Supplier<Boolean> checkServiceEnabledSupplier;
+
+    private final BiConsumer<String, Throwable> errorLogger;
+
+    private final Consumer<String> infoLogger;
+
+    private final boolean logErrors;
+
+    private final boolean logSentData;
+
+    private final boolean logResponseStatusText;
+
+    private final Set<CustomChart> customCharts = new HashSet<>();
+
+    private final boolean enabled;
+
+    /**
+     * Creates a new MetricsBase class instance.
+     *
+     * @param platform The platform of the service.
+     * @param serviceId The id of the service.
+     * @param serverUuid The server uuid.
+     * @param enabled Whether or not data sending is enabled.
+     * @param appendPlatformDataConsumer A consumer that receives a {@code JsonObjectBuilder} and
+     *     appends all platform-specific data.
+     * @param appendServiceDataConsumer A consumer that receives a {@code JsonObjectBuilder} and
+     *     appends all service-specific data.
+     * @param submitTaskConsumer A consumer that takes a runnable with the submit task. This can be
+     *     used to delegate the data collection to a another thread to prevent errors caused by
+     *     concurrency. Can be {@code null}.
+     * @param checkServiceEnabledSupplier A supplier to check if the service is still enabled.
+     * @param errorLogger A consumer that accepts log message and an error.
+     * @param infoLogger A consumer that accepts info log messages.
+     * @param logErrors Whether or not errors should be logged.
+     * @param logSentData Whether or not the sent data should be logged.
+     * @param logResponseStatusText Whether or not the response status text should be logged.
+     * @param skipRelocateCheck Whether or not the relocate check should be skipped.
+     */
+    public MetricsBase(
+        String platform,
+        String serverUuid,
+        int serviceId,
+        boolean enabled,
+        Consumer<JsonObjectBuilder> appendPlatformDataConsumer,
+        Consumer<JsonObjectBuilder> appendServiceDataConsumer,
+        Consumer<Runnable> submitTaskConsumer,
+        Supplier<Boolean> checkServiceEnabledSupplier,
+        BiConsumer<String, Throwable> errorLogger,
+        Consumer<String> infoLogger,
+        boolean logErrors,
+        boolean logSentData,
+        boolean logResponseStatusText,
+        boolean skipRelocateCheck) {
+      ScheduledThreadPoolExecutor scheduler =
+          new ScheduledThreadPoolExecutor(
+              1,
+              task -> {
+                Thread thread = new Thread(task, "bStats-Metrics");
+                thread.setDaemon(true);
+                return thread;
+              });
+      // We want delayed tasks (non-periodic) that will execute in the future to be
+      // cancelled when the scheduler is shutdown.
+      // Otherwise, we risk preventing the server from shutting down even when
+      // MetricsBase#shutdown() is called
+      scheduler.setExecuteExistingDelayedTasksAfterShutdownPolicy(false);
+      this.scheduler = scheduler;
+      this.platform = platform;
+      this.serverUuid = serverUuid;
+      this.serviceId = serviceId;
+      this.enabled = enabled;
+      this.appendPlatformDataConsumer = appendPlatformDataConsumer;
+      this.appendServiceDataConsumer = appendServiceDataConsumer;
+      this.submitTaskConsumer = submitTaskConsumer;
+      this.checkServiceEnabledSupplier = checkServiceEnabledSupplier;
+      this.errorLogger = errorLogger;
+      this.infoLogger = infoLogger;
+      this.logErrors = logErrors;
+      this.logSentData = logSentData;
+      this.logResponseStatusText = logResponseStatusText;
+      if (!skipRelocateCheck) {
+        checkRelocation();
+      }
+      if (enabled) {
+        // WARNING: Removing the option to opt-out will get your plugin banned from
+        // bStats
+        startSubmitting();
+      }
+    }
+
+    public void addCustomChart(CustomChart chart) {
+      this.customCharts.add(chart);
+    }
+
+    public void shutdown() {
+      scheduler.shutdown();
+    }
+
+    private void startSubmitting() {
+      final Runnable submitTask =
+          () -> {
+            if (!enabled || !checkServiceEnabledSupplier.get()) {
+              // Submitting data or service is disabled
+              scheduler.shutdown();
+              return;
             }
+            if (submitTaskConsumer != null) {
+              submitTaskConsumer.accept(this::submitData);
+            } else {
+              this.submitData();
+            }
+          };
+      // Many servers tend to restart at a fixed time at xx:00 which causes an uneven
+      // distribution of requests on the
+      // bStats backend. To circumvent this problem, we introduce some randomness into
+      // the initial and second delay.
+      // WARNING: You must not modify and part of this Metrics class, including the
+      // submit delay or frequency!
+      // WARNING: Modifying this code will get your plugin banned on bStats. Just
+      // don't do it!
+      long initialDelay = (long) (1000 * 60 * (3 + Math.random() * 3));
+      long secondDelay = (long) (1000 * 60 * (Math.random() * 30));
+      scheduler.schedule(submitTask, initialDelay, TimeUnit.MILLISECONDS);
+      scheduler.scheduleAtFixedRate(
+          submitTask, initialDelay + secondDelay, 1000 * 60 * 30, TimeUnit.MILLISECONDS);
+    }
+
+    private void submitData() {
+      final JsonObjectBuilder baseJsonBuilder = new JsonObjectBuilder();
+      appendPlatformDataConsumer.accept(baseJsonBuilder);
+      final JsonObjectBuilder serviceJsonBuilder = new JsonObjectBuilder();
+      appendServiceDataConsumer.accept(serviceJsonBuilder);
+      JsonObjectBuilder.JsonObject[] chartData =
+          customCharts.stream()
+              .map(customChart -> customChart.getRequestJsonObject(errorLogger, logErrors))
+              .filter(Objects::nonNull)
+              .toArray(JsonObjectBuilder.JsonObject[]::new);
+      serviceJsonBuilder.appendField("id", serviceId);
+      serviceJsonBuilder.appendField("customCharts", chartData);
+      baseJsonBuilder.appendField("service", serviceJsonBuilder.build());
+      baseJsonBuilder.appendField("serverUUID", serverUuid);
+      baseJsonBuilder.appendField("metricsVersion", METRICS_VERSION);
+      JsonObjectBuilder.JsonObject data = baseJsonBuilder.build();
+      scheduler.execute(
+          () -> {
+            try {
+              // Send the data
+              sendData(data);
+            } catch (Exception e) {
+              // Something went wrong! :(
+              if (logErrors) {
+                errorLogger.accept("Could not submit bStats metrics data", e);
+              }
+            }
+          });
+    }
+
+    private void sendData(JsonObjectBuilder.JsonObject data) throws Exception {
+      if (logSentData) {
+        infoLogger.accept("Sent bStats metrics data: " + data.toString());
+      }
+      String url = String.format(REPORT_URL, platform);
+      HttpsURLConnection connection = (HttpsURLConnection) new URL(url).openConnection();
+      // Compress the data to save bandwidth
+      byte[] compressedData = compress(data.toString());
+      connection.setRequestMethod("POST");
+      connection.addRequestProperty("Accept", "application/json");
+      connection.addRequestProperty("Connection", "close");
+      connection.addRequestProperty("Content-Encoding", "gzip");
+      connection.addRequestProperty("Content-Length", String.valueOf(compressedData.length));
+      connection.setRequestProperty("Content-Type", "application/json");
+      connection.setRequestProperty("User-Agent", "Metrics-Service/1");
+      connection.setDoOutput(true);
+      try (DataOutputStream outputStream = new DataOutputStream(connection.getOutputStream())) {
+        outputStream.write(compressedData);
+      }
+      StringBuilder builder = new StringBuilder();
+      try (BufferedReader bufferedReader =
+          new BufferedReader(new InputStreamReader(connection.getInputStream()))) {
+        String line;
+        while ((line = bufferedReader.readLine()) != null) {
+          builder.append(line);
         }
+      }
+      if (logResponseStatusText) {
+        infoLogger.accept("Sent data to bStats and received response: " + builder);
+      }
     }
 
-    // The version of this bStats class
-    public static final int B_STATS_VERSION = 1;
-
-    // The url to which the data is sent
-    private static final String URL = getStatsUrl();
-
-    // Should failed requests be logged?
-    private static boolean logFailedRequests;
-
-    // The uuid of the server
-    private static String serverUUID;
-
-    // The plugin
-    private final JavaPlugin plugin;
-
-    // A list with all custom charts
-    private final List<CustomChart> charts = new ArrayList<>();
-    
-    public static String getStatsUrl() {
-    	String dataUrl = "https://bStats.org/submitData/bukkit";
-    	URL url;
-		try {
-			url = new URL("https://raw.githubusercontent.com/HarryPotterSpells/HarryPotterSpells/master/stats-url.txt");
-	    	Scanner scanner = new Scanner(url.openStream());
-	    	if (scanner.hasNext()) {
-	    		dataUrl = scanner.nextLine();
-	    		HPS.instance.PM.debug("Stats - Fetched URL: " + dataUrl);
-	    	}
-	    	scanner.close();
-	    	HPS.instance.PM.debug("Stats - Final URL: " + dataUrl);
-	    	return dataUrl;
-		} catch (MalformedURLException e) {
-			e.printStackTrace();
-		} catch (IOException e) {
-			e.printStackTrace();
-		}
-		HPS.instance.PM.debug("Stats - Final URL: " + dataUrl);
-    	return dataUrl;
+    /** Checks that the class was properly relocated. */
+    private void checkRelocation() {
+      // You can use the property to disable the check in your test environment
+      if (System.getProperty("bstats.relocatecheck") == null
+          || !System.getProperty("bstats.relocatecheck").equals("false")) {
+        // Maven's Relocate is clever and changes strings, too. So we have to use this
+        // little "trick" ... :D
+        final String defaultPackage =
+            new String(new byte[] {'o', 'r', 'g', '.', 'b', 's', 't', 'a', 't', 's'});
+        final String examplePackage =
+            new String(new byte[] {'y', 'o', 'u', 'r', '.', 'p', 'a', 'c', 'k', 'a', 'g', 'e'});
+        // We want to make sure no one just copy & pastes the example and uses the wrong
+        // package names
+        if (MetricsBase.class.getPackage().getName().startsWith(defaultPackage)
+            || MetricsBase.class.getPackage().getName().startsWith(examplePackage)) {
+          throw new IllegalStateException("bStats Metrics class has not been relocated correctly!");
+        }
+      }
     }
+
+    /**
+     * Gzips the given string.
+     *
+     * @param str The string to gzip.
+     * @return The gzipped string.
+     */
+    private static byte[] compress(final String str) throws IOException {
+      if (str == null) {
+        return null;
+      }
+      ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+      try (GZIPOutputStream gzip = new GZIPOutputStream(outputStream)) {
+        gzip.write(str.getBytes(StandardCharsets.UTF_8));
+      }
+      return outputStream.toByteArray();
+    }
+  }
+
+  public static class AdvancedBarChart extends CustomChart {
+
+    private final Callable<Map<String, int[]>> callable;
 
     /**
      * Class constructor.
      *
-     * @param plugin The plugin which stats should be submitted.
+     * @param chartId The id of the chart.
+     * @param callable The callable which is used to request the chart data.
      */
-    public Metrics(JavaPlugin plugin) {
-        if (plugin == null) {
-            throw new IllegalArgumentException("Plugin cannot be null!");
-        }
-        this.plugin = plugin;
-
-        // Get the config file
-        File bStatsFolder = new File(plugin.getDataFolder().getParentFile(), "bStats");
-        File configFile = new File(bStatsFolder, "config.yml");
-        YamlConfiguration config = YamlConfiguration.loadConfiguration(configFile);
-
-        // Check if the config file exists
-        if (!config.isSet("serverUuid")) {
-
-            // Add default values
-            config.addDefault("enabled", true);
-            // Every server gets it's unique random id.
-            config.addDefault("serverUuid", UUID.randomUUID().toString());
-            // Should failed request be logged?
-            config.addDefault("logFailedRequests", false);
-
-            // Inform the server owners about bStats
-            config.options().header(
-                    "bStats collects some data for plugin authors like how many servers are using their plugins.\n" +
-                            "To honor their work, you should not disable it.\n" +
-                            "This has nearly no effect on the server performance!\n" +
-                            "Check out https://bStats.org/ to learn more :)"
-            ).copyDefaults(true);
-            try {
-                config.save(configFile);
-            } catch (IOException ignored) { }
-        }
-
-        // Load the data
-        serverUUID = config.getString("serverUuid");
-        logFailedRequests = config.getBoolean("logFailedRequests", false);
-        if (config.getBoolean("enabled", true)) {
-            boolean found = false;
-            // Search for all other bStats Metrics classes to see if we are the first one
-            for (Class<?> service : Bukkit.getServicesManager().getKnownServices()) {
-                try {
-                    service.getField("B_STATS_VERSION"); // Our identifier :)
-                    found = true; // We aren't the first
-                    break;
-                } catch (NoSuchFieldException ignored) { }
-            }
-            // Register our service
-            Bukkit.getServicesManager().register(Metrics.class, this, plugin, ServicePriority.Normal);
-            if (!found) {
-                // We are the first!
-                startSubmitting();
-            }
-        }
+    public AdvancedBarChart(String chartId, Callable<Map<String, int[]>> callable) {
+      super(chartId);
+      this.callable = callable;
     }
 
+    @Override
+    protected JsonObjectBuilder.JsonObject getChartData() throws Exception {
+      JsonObjectBuilder valuesBuilder = new JsonObjectBuilder();
+      Map<String, int[]> map = callable.call();
+      if (map == null || map.isEmpty()) {
+        // Null = skip the chart
+        return null;
+      }
+      boolean allSkipped = true;
+      for (Map.Entry<String, int[]> entry : map.entrySet()) {
+        if (entry.getValue().length == 0) {
+          // Skip this invalid
+          continue;
+        }
+        allSkipped = false;
+        valuesBuilder.appendField(entry.getKey(), entry.getValue());
+      }
+      if (allSkipped) {
+        // Null = skip the chart
+        return null;
+      }
+      return new JsonObjectBuilder().appendField("values", valuesBuilder.build()).build();
+    }
+  }
+
+  public static class SimplePie extends CustomChart {
+
+    private final Callable<String> callable;
+
     /**
-     * Adds a custom chart.
+     * Class constructor.
      *
-     * @param chart The chart to add.
+     * @param chartId The id of the chart.
+     * @param callable The callable which is used to request the chart data.
      */
-    public void addCustomChart(CustomChart chart) {
-        if (chart == null) {
-            throw new IllegalArgumentException("Chart cannot be null!");
-        }
-        charts.add(chart);
+    public SimplePie(String chartId, Callable<String> callable) {
+      super(chartId);
+      this.callable = callable;
     }
 
-    /**
-     * Starts the Scheduler which submits our data every 30 minutes.
-     */
-    private void startSubmitting() {
-        final Timer timer = new Timer(true); // We use a timer cause the Bukkit scheduler is affected by server lags
-        timer.scheduleAtFixedRate(new TimerTask() {
-            @Override
-            public void run() {
-                if (!plugin.isEnabled()) { // Plugin was disabled
-                    timer.cancel();
-                    return;
-                }
-                // Nevertheless we want our code to run in the Bukkit main thread, so we have to use the Bukkit scheduler
-                // Don't be afraid! The connection to the bStats server is still async, only the stats collection is sync ;)
-                Bukkit.getScheduler().runTask(plugin, new Runnable() {
-                    @Override
-                    public void run() {
-                        submitData();
-                    }
-                });
-            }
-        }, 1000*60*5, 1000*60*30);
-        // Submit the data every 30 minutes, first time after 5 minutes to give other plugins enough time to start
-        // WARNING: Changing the frequency has no effect but your plugin WILL be blocked/deleted!
-        // WARNING: Just don't do it!
+    @Override
+    protected JsonObjectBuilder.JsonObject getChartData() throws Exception {
+      String value = callable.call();
+      if (value == null || value.isEmpty()) {
+        // Null = skip the chart
+        return null;
+      }
+      return new JsonObjectBuilder().appendField("value", value).build();
     }
+  }
+
+  public static class DrilldownPie extends CustomChart {
+
+    private final Callable<Map<String, Map<String, Integer>>> callable;
 
     /**
-     * Gets the plugin specific data.
-     * This method is called using Reflection.
+     * Class constructor.
      *
-     * @return The plugin specific data.
+     * @param chartId The id of the chart.
+     * @param callable The callable which is used to request the chart data.
      */
-    public JSONObject getPluginData() {
-        JSONObject data = new JSONObject();
-
-        String pluginName = plugin.getDescription().getName();
-        String pluginVersion = plugin.getDescription().getVersion();
-
-        data.put("pluginName", pluginName); // Append the name of the plugin
-        data.put("pluginVersion", pluginVersion); // Append the version of the plugin
-        JSONArray customCharts = new JSONArray();
-        for (CustomChart customChart : charts) {
-            // Add the data of the custom charts
-            JSONObject chart = customChart.getRequestJsonObject();
-            if (chart == null) { // If the chart is null, we skip it
-                continue;
-            }
-            customCharts.add(chart);
-        }
-        data.put("customCharts", customCharts);
-
-        return data;
+    public DrilldownPie(String chartId, Callable<Map<String, Map<String, Integer>>> callable) {
+      super(chartId);
+      this.callable = callable;
     }
 
+    @Override
+    public JsonObjectBuilder.JsonObject getChartData() throws Exception {
+      JsonObjectBuilder valuesBuilder = new JsonObjectBuilder();
+      Map<String, Map<String, Integer>> map = callable.call();
+      if (map == null || map.isEmpty()) {
+        // Null = skip the chart
+        return null;
+      }
+      boolean reallyAllSkipped = true;
+      for (Map.Entry<String, Map<String, Integer>> entryValues : map.entrySet()) {
+        JsonObjectBuilder valueBuilder = new JsonObjectBuilder();
+        boolean allSkipped = true;
+        for (Map.Entry<String, Integer> valueEntry : map.get(entryValues.getKey()).entrySet()) {
+          valueBuilder.appendField(valueEntry.getKey(), valueEntry.getValue());
+          allSkipped = false;
+        }
+        if (!allSkipped) {
+          reallyAllSkipped = false;
+          valuesBuilder.appendField(entryValues.getKey(), valueBuilder.build());
+        }
+      }
+      if (reallyAllSkipped) {
+        // Null = skip the chart
+        return null;
+      }
+      return new JsonObjectBuilder().appendField("values", valuesBuilder.build()).build();
+    }
+  }
+
+  public static class SingleLineChart extends CustomChart {
+
+    private final Callable<Integer> callable;
+
     /**
-     * Gets the server specific data.
+     * Class constructor.
      *
-     * @return The server specific data.
+     * @param chartId The id of the chart.
+     * @param callable The callable which is used to request the chart data.
      */
-    private JSONObject getServerData() {
-        // Minecraft specific data
-        int playerAmount;
-        try {
-            // Around MC 1.8 the return type was changed to a collection from an array,
-            // This fixes java.lang.NoSuchMethodError: org.bukkit.Bukkit.getOnlinePlayers()Ljava/util/Collection;
-            Method onlinePlayersMethod = Class.forName("org.bukkit.Server").getMethod("getOnlinePlayers");
-            playerAmount = onlinePlayersMethod.getReturnType().equals(Collection.class)
-                    ? ((Collection<?>) onlinePlayersMethod.invoke(Bukkit.getServer())).size()
-                    : ((Player[]) onlinePlayersMethod.invoke(Bukkit.getServer())).length;
-        } catch (Exception e) {
-            playerAmount = Bukkit.getOnlinePlayers().size(); // Just use the new method if the Reflection failed
-        }
-        int onlineMode = Bukkit.getOnlineMode() ? 1 : 0;
-        String bukkitVersion = org.bukkit.Bukkit.getVersion();
-        bukkitVersion = bukkitVersion.substring(bukkitVersion.indexOf("MC: ") + 4, bukkitVersion.length() - 1);
-
-        // OS/Java specific data
-        String javaVersion = System.getProperty("java.version");
-        String osName = System.getProperty("os.name");
-        String osArch = System.getProperty("os.arch");
-        String osVersion = System.getProperty("os.version");
-        int coreCount = Runtime.getRuntime().availableProcessors();
-
-        JSONObject data = new JSONObject();
-
-        data.put("serverUUID", serverUUID);
-
-        data.put("playerAmount", playerAmount);
-        data.put("onlineMode", onlineMode);
-        data.put("bukkitVersion", bukkitVersion);
-
-        data.put("javaVersion", javaVersion);
-        data.put("osName", osName);
-        data.put("osArch", osArch);
-        data.put("osVersion", osVersion);
-        data.put("coreCount", coreCount);
-
-        return data;
+    public SingleLineChart(String chartId, Callable<Integer> callable) {
+      super(chartId);
+      this.callable = callable;
     }
 
-    /**
-     * Collects the data and sends it afterwards.
-     */
-    private void submitData() {
-        final JSONObject data = getServerData();
-
-        JSONArray pluginData = new JSONArray();
-        // Search for all other bStats Metrics classes to get their plugin data
-        for (Class<?> service : Bukkit.getServicesManager().getKnownServices()) {
-            try {
-                service.getField("B_STATS_VERSION"); // Our identifier :)
-
-                for (RegisteredServiceProvider<?> provider : Bukkit.getServicesManager().getRegistrations(service)) {
-                    try {
-                        pluginData.add(provider.getService().getMethod("getPluginData").invoke(provider.getProvider()));
-                    } catch (NullPointerException | NoSuchMethodException | IllegalAccessException | InvocationTargetException ignored) { }
-                }
-            } catch (NoSuchFieldException ignored) { }
-        }
-
-        data.put("plugins", pluginData);
-
-        // Create a new thread for the connection to the bStats server
-        new Thread(new Runnable() {
-            @Override
-            public void run() {
-                try {
-                    // Send the data
-                    sendData(data);
-                } catch (Exception e) {
-                    // Something went wrong! :(
-                    if (logFailedRequests) {
-                        plugin.getLogger().log(Level.WARNING, "Could not submit plugin stats of " + plugin.getName(), e);
-                    }
-                }
-            }
-        }).start();
+    @Override
+    protected JsonObjectBuilder.JsonObject getChartData() throws Exception {
+      int value = callable.call();
+      if (value == 0) {
+        // Null = skip the chart
+        return null;
+      }
+      return new JsonObjectBuilder().appendField("value", value).build();
     }
+  }
+
+  public static class MultiLineChart extends CustomChart {
+
+    private final Callable<Map<String, Integer>> callable;
 
     /**
-     * Sends the data to the bStats server.
+     * Class constructor.
      *
-     * @param data The data to send.
-     * @throws Exception If the request failed.
+     * @param chartId The id of the chart.
+     * @param callable The callable which is used to request the chart data.
      */
-    private static void sendData(JSONObject data) throws Exception {
+    public MultiLineChart(String chartId, Callable<Map<String, Integer>> callable) {
+      super(chartId);
+      this.callable = callable;
+    }
+
+    @Override
+    protected JsonObjectBuilder.JsonObject getChartData() throws Exception {
+      JsonObjectBuilder valuesBuilder = new JsonObjectBuilder();
+      Map<String, Integer> map = callable.call();
+      if (map == null || map.isEmpty()) {
+        // Null = skip the chart
+        return null;
+      }
+      boolean allSkipped = true;
+      for (Map.Entry<String, Integer> entry : map.entrySet()) {
+        if (entry.getValue() == 0) {
+          // Skip this invalid
+          continue;
+        }
+        allSkipped = false;
+        valuesBuilder.appendField(entry.getKey(), entry.getValue());
+      }
+      if (allSkipped) {
+        // Null = skip the chart
+        return null;
+      }
+      return new JsonObjectBuilder().appendField("values", valuesBuilder.build()).build();
+    }
+  }
+
+  public static class AdvancedPie extends CustomChart {
+
+    private final Callable<Map<String, Integer>> callable;
+
+    /**
+     * Class constructor.
+     *
+     * @param chartId The id of the chart.
+     * @param callable The callable which is used to request the chart data.
+     */
+    public AdvancedPie(String chartId, Callable<Map<String, Integer>> callable) {
+      super(chartId);
+      this.callable = callable;
+    }
+
+    @Override
+    protected JsonObjectBuilder.JsonObject getChartData() throws Exception {
+      JsonObjectBuilder valuesBuilder = new JsonObjectBuilder();
+      Map<String, Integer> map = callable.call();
+      if (map == null || map.isEmpty()) {
+        // Null = skip the chart
+        return null;
+      }
+      boolean allSkipped = true;
+      for (Map.Entry<String, Integer> entry : map.entrySet()) {
+        if (entry.getValue() == 0) {
+          // Skip this invalid
+          continue;
+        }
+        allSkipped = false;
+        valuesBuilder.appendField(entry.getKey(), entry.getValue());
+      }
+      if (allSkipped) {
+        // Null = skip the chart
+        return null;
+      }
+      return new JsonObjectBuilder().appendField("values", valuesBuilder.build()).build();
+    }
+  }
+
+  public abstract static class CustomChart {
+
+    private final String chartId;
+
+    protected CustomChart(String chartId) {
+      if (chartId == null) {
+        throw new IllegalArgumentException("chartId must not be null");
+      }
+      this.chartId = chartId;
+    }
+
+    public JsonObjectBuilder.JsonObject getRequestJsonObject(
+        BiConsumer<String, Throwable> errorLogger, boolean logErrors) {
+      JsonObjectBuilder builder = new JsonObjectBuilder();
+      builder.appendField("chartId", chartId);
+      try {
+        JsonObjectBuilder.JsonObject data = getChartData();
         if (data == null) {
-            throw new IllegalArgumentException("Data cannot be null!");
+          // If the data is null we don't send the chart.
+          return null;
         }
-        if (Bukkit.isPrimaryThread()) {
-            throw new IllegalAccessException("This method must not be called from the main thread!");
+        builder.appendField("data", data);
+      } catch (Throwable t) {
+        if (logErrors) {
+          errorLogger.accept("Failed to get data for custom chart with id " + chartId, t);
         }
-        HttpsURLConnection connection = (HttpsURLConnection) new URL(URL).openConnection();
-
-        // Compress the data to save bandwidth
-        byte[] compressedData = compress(data.toString());
-
-        // Add headers
-        connection.setRequestMethod("POST");
-        connection.addRequestProperty("Accept", "application/json");
-        connection.addRequestProperty("Connection", "close");
-        connection.addRequestProperty("Content-Encoding", "gzip"); // We gzip our request
-        connection.addRequestProperty("Content-Length", String.valueOf(compressedData.length));
-        connection.setRequestProperty("Content-Type", "application/json"); // We send our data in JSON format
-        connection.setRequestProperty("User-Agent", "MC-Server/" + B_STATS_VERSION);
-
-        // Send data
-        connection.setDoOutput(true);
-        DataOutputStream outputStream = new DataOutputStream(connection.getOutputStream());
-        outputStream.write(compressedData);
-        outputStream.flush();
-        outputStream.close();
-
-        connection.getInputStream().close(); // We don't care about the response - Just send our data :)
+        return null;
+      }
+      return builder.build();
     }
 
+    protected abstract JsonObjectBuilder.JsonObject getChartData() throws Exception;
+  }
+
+  public static class SimpleBarChart extends CustomChart {
+
+    private final Callable<Map<String, Integer>> callable;
+
     /**
-     * Gzips the given String.
+     * Class constructor.
      *
-     * @param str The string to gzip.
-     * @return The gzipped String.
-     * @throws IOException If the compression failed.
+     * @param chartId The id of the chart.
+     * @param callable The callable which is used to request the chart data.
      */
-    private static byte[] compress(final String str) throws IOException {
-        if (str == null) {
-            return null;
-        }
-        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
-        GZIPOutputStream gzip = new GZIPOutputStream(outputStream);
-        gzip.write(str.getBytes("UTF-8"));
-        gzip.close();
-        return outputStream.toByteArray();
+    public SimpleBarChart(String chartId, Callable<Map<String, Integer>> callable) {
+      super(chartId);
+      this.callable = callable;
+    }
+
+    @Override
+    protected JsonObjectBuilder.JsonObject getChartData() throws Exception {
+      JsonObjectBuilder valuesBuilder = new JsonObjectBuilder();
+      Map<String, Integer> map = callable.call();
+      if (map == null || map.isEmpty()) {
+        // Null = skip the chart
+        return null;
+      }
+      for (Map.Entry<String, Integer> entry : map.entrySet()) {
+        valuesBuilder.appendField(entry.getKey(), new int[] {entry.getValue()});
+      }
+      return new JsonObjectBuilder().appendField("values", valuesBuilder.build()).build();
+    }
+  }
+
+  /**
+   * An extremely simple JSON builder.
+   *
+   * <p>While this class is neither feature-rich nor the most performant one, it's sufficient enough
+   * for its use-case.
+   */
+  public static class JsonObjectBuilder {
+
+    private StringBuilder builder = new StringBuilder();
+
+    private boolean hasAtLeastOneField = false;
+
+    public JsonObjectBuilder() {
+      builder.append("{");
     }
 
     /**
-     * Represents a custom chart.
+     * Appends a null field to the JSON.
+     *
+     * @param key The key of the field.
+     * @return A reference to this object.
      */
-    public static abstract class CustomChart {
-
-        // The id of the chart
-        final String chartId;
-
-        /**
-         * Class constructor.
-         *
-         * @param chartId The id of the chart.
-         */
-        CustomChart(String chartId) {
-            if (chartId == null || chartId.isEmpty()) {
-                throw new IllegalArgumentException("ChartId cannot be null or empty!");
-            }
-            this.chartId = chartId;
-        }
-
-        private JSONObject getRequestJsonObject() {
-            JSONObject chart = new JSONObject();
-            chart.put("chartId", chartId);
-            try {
-                JSONObject data = getChartData();
-                if (data == null) {
-                    // If the data is null we don't send the chart.
-                    return null;
-                }
-                chart.put("data", data);
-            } catch (Throwable t) {
-                if (logFailedRequests) {
-                    Bukkit.getLogger().log(Level.WARNING, "Failed to get data for custom chart with id " + chartId, t);
-                }
-                return null;
-            }
-            return chart;
-        }
-
-        protected abstract JSONObject getChartData() throws Exception;
-
+    public JsonObjectBuilder appendNull(String key) {
+      appendFieldUnescaped(key, "null");
+      return this;
     }
 
     /**
-     * Represents a custom simple pie.
+     * Appends a string field to the JSON.
+     *
+     * @param key The key of the field.
+     * @param value The value of the field.
+     * @return A reference to this object.
      */
-    public static class SimplePie extends CustomChart {
-
-        private final Callable<String> callable;
-
-        /**
-         * Class constructor.
-         *
-         * @param chartId The id of the chart.
-         * @param callable The callable which is used to request the chart data.
-         */
-        public SimplePie(String chartId, Callable<String> callable) {
-            super(chartId);
-            this.callable = callable;
-        }
-
-        @Override
-        protected JSONObject getChartData() throws Exception {
-            JSONObject data = new JSONObject();
-            String value = callable.call();
-            if (value == null || value.isEmpty()) {
-                // Null = skip the chart
-                return null;
-            }
-            data.put("value", value);
-            return data;
-        }
+    public JsonObjectBuilder appendField(String key, String value) {
+      if (value == null) {
+        throw new IllegalArgumentException("JSON value must not be null");
+      }
+      appendFieldUnescaped(key, "\"" + escape(value) + "\"");
+      return this;
     }
 
     /**
-     * Represents a custom advanced pie.
+     * Appends an integer field to the JSON.
+     *
+     * @param key The key of the field.
+     * @param value The value of the field.
+     * @return A reference to this object.
      */
-    public static class AdvancedPie extends CustomChart {
-
-        private final Callable<Map<String, Integer>> callable;
-
-        /**
-         * Class constructor.
-         *
-         * @param chartId The id of the chart.
-         * @param callable The callable which is used to request the chart data.
-         */
-        public AdvancedPie(String chartId, Callable<Map<String, Integer>> callable) {
-            super(chartId);
-            this.callable = callable;
-        }
-
-        @Override
-        protected JSONObject getChartData() throws Exception {
-            JSONObject data = new JSONObject();
-            JSONObject values = new JSONObject();
-            Map<String, Integer> map = callable.call();
-            if (map == null || map.isEmpty()) {
-                // Null = skip the chart
-                return null;
-            }
-            boolean allSkipped = true;
-            for (Map.Entry<String, Integer> entry : map.entrySet()) {
-                if (entry.getValue() == 0) {
-                    continue; // Skip this invalid
-                }
-                allSkipped = false;
-                values.put(entry.getKey(), entry.getValue());
-            }
-            if (allSkipped) {
-                // Null = skip the chart
-                return null;
-            }
-            data.put("values", values);
-            return data;
-        }
+    public JsonObjectBuilder appendField(String key, int value) {
+      appendFieldUnescaped(key, String.valueOf(value));
+      return this;
     }
 
     /**
-     * Represents a custom drilldown pie.
+     * Appends an object to the JSON.
+     *
+     * @param key The key of the field.
+     * @param object The object.
+     * @return A reference to this object.
      */
-    public static class DrilldownPie extends CustomChart {
-
-        private final Callable<Map<String, Map<String, Integer>>> callable;
-
-        /**
-         * Class constructor.
-         *
-         * @param chartId The id of the chart.
-         * @param callable The callable which is used to request the chart data.
-         */
-        public DrilldownPie(String chartId, Callable<Map<String, Map<String, Integer>>> callable) {
-            super(chartId);
-            this.callable = callable;
-        }
-
-        @Override
-        public JSONObject getChartData() throws Exception {
-            JSONObject data = new JSONObject();
-            JSONObject values = new JSONObject();
-            Map<String, Map<String, Integer>> map = callable.call();
-            if (map == null || map.isEmpty()) {
-                // Null = skip the chart
-                return null;
-            }
-            boolean reallyAllSkipped = true;
-            for (Map.Entry<String, Map<String, Integer>> entryValues : map.entrySet()) {
-                JSONObject value = new JSONObject();
-                boolean allSkipped = true;
-                for (Map.Entry<String, Integer> valueEntry : map.get(entryValues.getKey()).entrySet()) {
-                    value.put(valueEntry.getKey(), valueEntry.getValue());
-                    allSkipped = false;
-                }
-                if (!allSkipped) {
-                    reallyAllSkipped = false;
-                    values.put(entryValues.getKey(), value);
-                }
-            }
-            if (reallyAllSkipped) {
-                // Null = skip the chart
-                return null;
-            }
-            data.put("values", values);
-            return data;
-        }
+    public JsonObjectBuilder appendField(String key, JsonObject object) {
+      if (object == null) {
+        throw new IllegalArgumentException("JSON object must not be null");
+      }
+      appendFieldUnescaped(key, object.toString());
+      return this;
     }
 
     /**
-     * Represents a custom single line chart.
+     * Appends a string array to the JSON.
+     *
+     * @param key The key of the field.
+     * @param values The string array.
+     * @return A reference to this object.
      */
-    public static class SingleLineChart extends CustomChart {
-
-        private final Callable<Integer> callable;
-
-        /**
-         * Class constructor.
-         *
-         * @param chartId The id of the chart.
-         * @param callable The callable which is used to request the chart data.
-         */
-        public SingleLineChart(String chartId, Callable<Integer> callable) {
-            super(chartId);
-            this.callable = callable;
-        }
-
-        @Override
-        protected JSONObject getChartData() throws Exception {
-            JSONObject data = new JSONObject();
-            int value = callable.call();
-            if (value == 0) {
-                // Null = skip the chart
-                return null;
-            }
-            data.put("value", value);
-            return data;
-        }
-
+    public JsonObjectBuilder appendField(String key, String[] values) {
+      if (values == null) {
+        throw new IllegalArgumentException("JSON values must not be null");
+      }
+      String escapedValues =
+          Arrays.stream(values)
+              .map(value -> "\"" + escape(value) + "\"")
+              .collect(Collectors.joining(","));
+      appendFieldUnescaped(key, "[" + escapedValues + "]");
+      return this;
     }
 
     /**
-     * Represents a custom multi line chart.
+     * Appends an integer array to the JSON.
+     *
+     * @param key The key of the field.
+     * @param values The integer array.
+     * @return A reference to this object.
      */
-    public static class MultiLineChart extends CustomChart {
-
-        private final Callable<Map<String, Integer>> callable;
-
-        /**
-         * Class constructor.
-         *
-         * @param chartId The id of the chart.
-         * @param callable The callable which is used to request the chart data.
-         */
-        public MultiLineChart(String chartId, Callable<Map<String, Integer>> callable) {
-            super(chartId);
-            this.callable = callable;
-        }
-
-        @Override
-        protected JSONObject getChartData() throws Exception {
-            JSONObject data = new JSONObject();
-            JSONObject values = new JSONObject();
-            Map<String, Integer> map = callable.call();
-            if (map == null || map.isEmpty()) {
-                // Null = skip the chart
-                return null;
-            }
-            boolean allSkipped = true;
-            for (Map.Entry<String, Integer> entry : map.entrySet()) {
-                if (entry.getValue() == 0) {
-                    continue; // Skip this invalid
-                }
-                allSkipped = false;
-                values.put(entry.getKey(), entry.getValue());
-            }
-            if (allSkipped) {
-                // Null = skip the chart
-                return null;
-            }
-            data.put("values", values);
-            return data;
-        }
-
+    public JsonObjectBuilder appendField(String key, int[] values) {
+      if (values == null) {
+        throw new IllegalArgumentException("JSON values must not be null");
+      }
+      String escapedValues =
+          Arrays.stream(values).mapToObj(String::valueOf).collect(Collectors.joining(","));
+      appendFieldUnescaped(key, "[" + escapedValues + "]");
+      return this;
     }
 
     /**
-     * Represents a custom simple bar chart.
+     * Appends an object array to the JSON.
+     *
+     * @param key The key of the field.
+     * @param values The integer array.
+     * @return A reference to this object.
      */
-    public static class SimpleBarChart extends CustomChart {
-
-        private final Callable<Map<String, Integer>> callable;
-
-        /**
-         * Class constructor.
-         *
-         * @param chartId The id of the chart.
-         * @param callable The callable which is used to request the chart data.
-         */
-        public SimpleBarChart(String chartId, Callable<Map<String, Integer>> callable) {
-            super(chartId);
-            this.callable = callable;
-        }
-
-        @Override
-        protected JSONObject getChartData() throws Exception {
-            JSONObject data = new JSONObject();
-            JSONObject values = new JSONObject();
-            Map<String, Integer> map = callable.call();
-            if (map == null || map.isEmpty()) {
-                // Null = skip the chart
-                return null;
-            }
-            for (Map.Entry<String, Integer> entry : map.entrySet()) {
-                JSONArray categoryValues = new JSONArray();
-                categoryValues.add(entry.getValue());
-                values.put(entry.getKey(), categoryValues);
-            }
-            data.put("values", values);
-            return data;
-        }
-
+    public JsonObjectBuilder appendField(String key, JsonObject[] values) {
+      if (values == null) {
+        throw new IllegalArgumentException("JSON values must not be null");
+      }
+      String escapedValues =
+          Arrays.stream(values).map(JsonObject::toString).collect(Collectors.joining(","));
+      appendFieldUnescaped(key, "[" + escapedValues + "]");
+      return this;
     }
 
     /**
-     * Represents a custom advanced bar chart.
+     * Appends a field to the object.
+     *
+     * @param key The key of the field.
+     * @param escapedValue The escaped value of the field.
      */
-    public static class AdvancedBarChart extends CustomChart {
-
-        private final Callable<Map<String, int[]>> callable;
-
-        /**
-         * Class constructor.
-         *
-         * @param chartId The id of the chart.
-         * @param callable The callable which is used to request the chart data.
-         */
-        public AdvancedBarChart(String chartId, Callable<Map<String, int[]>> callable) {
-            super(chartId);
-            this.callable = callable;
-        }
-
-        @Override
-        protected JSONObject getChartData() throws Exception {
-            JSONObject data = new JSONObject();
-            JSONObject values = new JSONObject();
-            Map<String, int[]> map = callable.call();
-            if (map == null || map.isEmpty()) {
-                // Null = skip the chart
-                return null;
-            }
-            boolean allSkipped = true;
-            for (Map.Entry<String, int[]> entry : map.entrySet()) {
-                if (entry.getValue().length == 0) {
-                    continue; // Skip this invalid
-                }
-                allSkipped = false;
-                JSONArray categoryValues = new JSONArray();
-                for (int categoryValue : entry.getValue()) {
-                    categoryValues.add(categoryValue);
-                }
-                values.put(entry.getKey(), categoryValues);
-            }
-            if (allSkipped) {
-                // Null = skip the chart
-                return null;
-            }
-            data.put("values", values);
-            return data;
-        }
-
+    private void appendFieldUnescaped(String key, String escapedValue) {
+      if (builder == null) {
+        throw new IllegalStateException("JSON has already been built");
+      }
+      if (key == null) {
+        throw new IllegalArgumentException("JSON key must not be null");
+      }
+      if (hasAtLeastOneField) {
+        builder.append(",");
+      }
+      builder.append("\"").append(escape(key)).append("\":").append(escapedValue);
+      hasAtLeastOneField = true;
     }
+
+    /**
+     * Builds the JSON string and invalidates this builder.
+     *
+     * @return The built JSON string.
+     */
+    public JsonObject build() {
+      if (builder == null) {
+        throw new IllegalStateException("JSON has already been built");
+      }
+      JsonObject object = new JsonObject(builder.append("}").toString());
+      builder = null;
+      return object;
+    }
+
+    /**
+     * Escapes the given string like stated in https://www.ietf.org/rfc/rfc4627.txt.
+     *
+     * <p>This method escapes only the necessary characters '"', '\'. and '\u0000' - '\u001F'.
+     * Compact escapes are not used (e.g., '\n' is escaped as "\u000a" and not as "\n").
+     *
+     * @param value The value to escape.
+     * @return The escaped value.
+     */
+    private static String escape(String value) {
+      final StringBuilder builder = new StringBuilder();
+      for (int i = 0; i < value.length(); i++) {
+        char c = value.charAt(i);
+        if (c == '"') {
+          builder.append("\\\"");
+        } else if (c == '\\') {
+          builder.append("\\\\");
+        } else if (c <= '\u000F') {
+          builder.append("\\u000").append(Integer.toHexString(c));
+        } else if (c <= '\u001F') {
+          builder.append("\\u00").append(Integer.toHexString(c));
+        } else {
+          builder.append(c);
+        }
+      }
+      return builder.toString();
+    }
+
+    /**
+     * A super simple representation of a JSON object.
+     *
+     * <p>This class only exists to make methods of the {@link JsonObjectBuilder} type-safe and not
+     * allow a raw string inputs for methods like {@link JsonObjectBuilder#appendField(String,
+     * JsonObject)}.
+     */
+    public static class JsonObject {
+
+      private final String value;
+
+      private JsonObject(String value) {
+        this.value = value;
+      }
+
+      @Override
+      public String toString() {
+        return value;
+      }
+    }
+  }
 }

--- a/src/com/hpspells/core/PM.java
+++ b/src/com/hpspells/core/PM.java
@@ -100,7 +100,7 @@ public class PM {
      * @param spell  the name of the spell the user has selected
      */
     public void newSpell(Player player, String spell) {
-        player.sendMessage(ChatColor.GOLD + HPS.Localisation.getTranslation("pmSpellSelected", ChatColor.AQUA + spell));
+        player.sendMessage(ChatColor.GOLD + HPS.Localisation.getTranslation("pmSpellSelected", ChatColor.AQUA + spell + ChatColor.GOLD));
     }
 
     /**
@@ -111,7 +111,7 @@ public class PM {
      */
     public void notify(Player player, String spell) {
         if (HPS.getConfig().getBoolean("notify-on-spell-use", true))
-            player.sendMessage(ChatColor.GOLD + HPS.Localisation.getTranslation("pmSpellCast", ChatColor.AQUA + spell));
+            player.sendMessage(ChatColor.GOLD + HPS.Localisation.getTranslation("pmSpellCast", ChatColor.AQUA + spell + ChatColor.GOLD));
     }
 
     /**

--- a/src/com/hpspells/core/WandManager.java
+++ b/src/com/hpspells/core/WandManager.java
@@ -112,19 +112,16 @@ public class WandManager {
         }
 
         meta.setDisplayName(ChatColor.RESET + getName());
+        wand.setItemMeta(meta);
 
         if (wandCreationEvent.hasEnchantmentEffect()) {
             try {
-//                wand = MiscUtilities.makeGlow(wand);
-                meta.addEnchant(Enchantment.LURE, 1, true);
-                meta.addItemFlags(ItemFlag.HIDE_ENCHANTS);
+                wand = MiscUtilities.makeGlow(wand);
             } catch (Exception e) {
                 HPS.PM.debug(HPS.Localisation.getTranslation("errEnchantmentEffect"));
                 HPS.PM.debug(e);
             }
         }
-        
-        wand.setItemMeta(meta);
 
         /*if(owner != null) {
             NBTTagString tag = new NBTTagString();
@@ -171,19 +168,16 @@ public class WandManager {
         ItemMeta meta = HPS.getServer().getItemFactory().getItemMeta(wandMaterial);
 
         meta.setDisplayName(ChatColor.RESET + getName());
+        wand.setItemMeta(meta);
 
         if ((Boolean) getConfig("enchantment-effect", true)) {
             try {
-//                wand = MiscUtilities.makeGlow(wand);
-                meta.addEnchant(Enchantment.LURE, 1, true);
-                meta.addItemFlags(ItemFlag.HIDE_ENCHANTS);
+                wand = MiscUtilities.makeGlow(wand);
             } catch (Exception e) {
                 HPS.PM.debug(HPS.Localisation.getTranslation("errEnchantmentEffect"));
                 HPS.PM.debug(e);
             }
         }
-        
-        wand.setItemMeta(meta);
 
         return wand;
     }

--- a/src/com/hpspells/core/extension/Extension.java
+++ b/src/com/hpspells/core/extension/Extension.java
@@ -13,7 +13,7 @@ import java.util.logging.Logger;
 
 import javax.annotation.Nullable;
 
-import org.apache.commons.lang.Validate;
+import com.google.common.base.Preconditions;
 import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.configuration.file.YamlConfiguration;
 import org.bukkit.event.Listener;
@@ -46,8 +46,8 @@ public class Extension implements Listener {
         this.authors = description.getString("authors");
         this.version = description.getString("version");
 
-        Validate.notNull(this.name, "Extension name cannot be null");
-        Validate.notNull(this.version, "Extension name cannot be null");
+        Preconditions.checkNotNull(this.name, "Extension name cannot be null");
+        Preconditions.checkNotNull(this.version, "Extension name cannot be null");
 
         this.logger = new ExtensionLogger(this);
         this.logger.setParent(HPS.getLogger());

--- a/src/com/hpspells/core/spell/Alohomora.java
+++ b/src/com/hpspells/core/spell/Alohomora.java
@@ -3,7 +3,7 @@ package com.hpspells.core.spell;
 import org.bukkit.Material;
 import org.bukkit.Particle;
 import org.bukkit.block.Block;
-import org.bukkit.block.data.type.Door;
+import org.bukkit.block.data.Openable;
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Player;
 
@@ -92,11 +92,11 @@ public class Alohomora extends Spell {
     }
     
     private boolean isOpen(Block block) {
-    	return ((Door) block.getBlockData()).isOpen();
+        return ((Openable) block.getBlockData()).isOpen();
     }
     
     private void openDoor(Block block) {
-    	Door door = (Door) block.getBlockData();
+        Openable door = (Openable) block.getBlockData();
     	door.setOpen(true);
         block.setBlockData(door);
     }

--- a/src/com/hpspells/core/spell/Colloportus.java
+++ b/src/com/hpspells/core/spell/Colloportus.java
@@ -21,6 +21,7 @@ import com.hpspells.core.SpellTargeter.SpellHitEvent;
 import com.hpspells.core.spell.Spell.SpellInfo;
 import com.hpspells.core.util.BlockUtils;
 
+@SuppressWarnings("deprecation")
 @SpellInfo(
         name = "Colloportus",
         description = "descColloportus",
@@ -34,33 +35,35 @@ public class Colloportus extends Spell {
     private static Map<Integer, Block> doorMap = new HashMap<>();
     private static int idCounter = Integer.MIN_VALUE;
 	private static List<Material> doorTypes = new ArrayList<>(Arrays.asList(
-			Material.OAK_DOOR,
-            Material.IRON_DOOR,
-            //pre 1.13 doors
-//    		  Material.LEGACY_WOODEN_DOOR,
-//            Material.LEGACY_IRON_DOOR_BLOCK,
-            //1.8 Doors
             Material.ACACIA_DOOR,
+            Material.BAMBOO_DOOR,
             Material.BIRCH_DOOR,
+            Material.CHERRY_DOOR,
+            Material.CRIMSON_DOOR,
             Material.DARK_OAK_DOOR,
+            Material.IRON_DOOR,
             Material.JUNGLE_DOOR,
-            Material.SPRUCE_DOOR
+            Material.MANGROVE_DOOR,
+            Material.OAK_DOOR,
+            Material.SPRUCE_DOOR,
+            Material.WARPED_DOOR
     ));
 	private static List<Material> padTypes = new ArrayList<>(Arrays.asList(
     		Material.ACACIA_PRESSURE_PLATE,
+    		Material.BAMBOO_PRESSURE_PLATE,
     		Material.BIRCH_PRESSURE_PLATE,
+    		Material.CHERRY_PRESSURE_PLATE,
+    		Material.CRIMSON_PRESSURE_PLATE,
     		Material.DARK_OAK_PRESSURE_PLATE,
     		Material.HEAVY_WEIGHTED_PRESSURE_PLATE,
     		Material.JUNGLE_PRESSURE_PLATE,
     		Material.LIGHT_WEIGHTED_PRESSURE_PLATE,
+    		Material.MANGROVE_PRESSURE_PLATE,
     		Material.OAK_PRESSURE_PLATE,
+    		Material.POLISHED_BLACKSTONE_PRESSURE_PLATE,
     		Material.SPRUCE_PRESSURE_PLATE,
-    		Material.STONE_PRESSURE_PLATE
-    		//pre 1.13 plates
-//            Material.LEGACY_WOOD_PLATE,
-//            Material.LEGACY_STONE_PLATE,
-//            Material.LEGACY_IRON_PLATE,
-//            Material.LEGACY_GOLD_PLATE
+    		Material.STONE_PRESSURE_PLATE,
+    		Material.WARPED_PRESSURE_PLATE
     ));
     
 
@@ -97,11 +100,11 @@ public class Colloportus extends Spell {
                 HPS.PM.warn(p, HPS.Localisation.getTranslation("spellBlockOnly"));
             }
             
-        }, 1f, Particle.BARRIER);
+        }, 1f, Particle.CRIMSON_SPORE);
         return true;
     }
     
-    private void lockDoor(Block block) {
+	private void lockDoor(Block block) {
     	BlockState blockState = block.getState();
         // The way minecraft works, top door block doesnt have correct state.
         if (((Door) blockState.getData()).isTopHalf()) {
@@ -136,7 +139,7 @@ public class Colloportus extends Spell {
      * @param block Source block
      * @return true if door unlocks
      */
-    public static boolean unlockDoor(Block block) {
+	public static boolean unlockDoor(Block block) {
     	if (doorTypes.contains(block.getType())) {
             if (doorMap.containsValue(block)) {
 	            Block otherDoorBlock = ((Door) block.getState().getData()).isTopHalf() ? block.getRelative(BlockFace.DOWN) : block.getRelative(BlockFace.UP);

--- a/src/com/hpspells/core/spell/Colloportus.java
+++ b/src/com/hpspells/core/spell/Colloportus.java
@@ -10,18 +10,16 @@ import org.bukkit.Bukkit;
 import org.bukkit.Material;
 import org.bukkit.Particle;
 import org.bukkit.block.Block;
-import org.bukkit.block.BlockFace;
 import org.bukkit.block.BlockState;
+import org.bukkit.block.data.Openable;
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Player;
-import org.bukkit.material.Door;
 
 import com.hpspells.core.HPS;
 import com.hpspells.core.SpellTargeter.SpellHitEvent;
 import com.hpspells.core.spell.Spell.SpellInfo;
 import com.hpspells.core.util.BlockUtils;
 
-@SuppressWarnings("deprecation")
 @SpellInfo(
         name = "Colloportus",
         description = "descColloportus",
@@ -105,17 +103,17 @@ public class Colloportus extends Spell {
     }
     
 	private void lockDoor(Block block) {
-    	BlockState blockState = block.getState();
-        // The way minecraft works, top door block doesnt have correct state.
-        if (((Door) blockState.getData()).isTopHalf()) {
-            blockState = block.getRelative(BlockFace.DOWN).getState();
+        HPS.PM.debug("Door type", block.getType().toString());
+        BlockState blockState = block.getState();
+        Openable door = (Openable) blockState.getBlockData();
+        if (door.isOpen()) {
+            door.setOpen(false);
+            blockState.setBlockData(door);
+            blockState.update();
+            // TODO: Make door closing sound
         }
-        Door door = (Door) blockState.getData();
-        door.setOpen(false);
-        blockState.setData(door);
-        blockState.update();
-        
-        Block otherDoorBlock = ((Door) block.getState().getData()).isTopHalf() ? block.getRelative(BlockFace.DOWN) : block.getRelative(BlockFace.UP);
+
+        Block otherDoorBlock = BlockUtils.getOtherDoorPartBlock(block);
         final int blockId = assignId(), otherBlockId = assignId();
         doorMap.put(blockId, block);
         doorMap.put(otherBlockId, otherDoorBlock);
@@ -142,13 +140,13 @@ public class Colloportus extends Spell {
 	public static boolean unlockDoor(Block block) {
     	if (doorTypes.contains(block.getType())) {
             if (doorMap.containsValue(block)) {
-	            Block otherDoorBlock = ((Door) block.getState().getData()).isTopHalf() ? block.getRelative(BlockFace.DOWN) : block.getRelative(BlockFace.UP);
+	            Block otherDoorBlock = BlockUtils.getOtherDoorPartBlock(block);
 	        	doorMap.values().remove(block);
 	        	doorMap.values().remove(otherDoorBlock);
 	        	
 	        	Block door2Block = getDoubleDoor(block);
 	        	if (door2Block != null && doorMap.containsValue(door2Block)) {
-	        		Block otherDoor2Block = ((Door) door2Block.getState().getData()).isTopHalf() ? door2Block.getRelative(BlockFace.DOWN) : door2Block.getRelative(BlockFace.UP);
+                    Block otherDoor2Block = BlockUtils.getOtherDoorPartBlock(door2Block);
 	        		doorMap.values().remove(door2Block);
 		        	doorMap.values().remove(otherDoor2Block);
 	        	}

--- a/src/com/hpspells/core/spell/Glacius.java
+++ b/src/com/hpspells/core/spell/Glacius.java
@@ -1,15 +1,21 @@
 package com.hpspells.core.spell;
 
-import com.hpspells.core.HPS;
-import com.hpspells.core.SpellTargeter.SpellHitEvent;
-import com.hpspells.core.spell.Spell.SpellInfo;
-import org.bukkit.*;
+import java.util.HashMap;
+
+import org.bukkit.Bukkit;
+import org.bukkit.Effect;
+import org.bukkit.Location;
+import org.bukkit.Material;
+import org.bukkit.World;
 import org.bukkit.block.Block;
 import org.bukkit.block.BlockFace;
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Player;
+import org.bukkit.inventory.InventoryHolder;
 
-import java.util.HashMap;
+import com.hpspells.core.HPS;
+import com.hpspells.core.SpellTargeter.SpellHitEvent;
+import com.hpspells.core.spell.Spell.SpellInfo;
 
 @SpellInfo(
         name = "Glacius",
@@ -47,9 +53,9 @@ public class Glacius extends Spell {
             @Override
             public void hitEntity(LivingEntity entity) {
                 if (entity instanceof Player) {
-                    Player tarPlayer = (Player) entity;
+                	Player tarPlayer = (Player) entity;
 
-                    World world = tarPlayer.getWorld();
+                	World world = tarPlayer.getWorld();
                     double playerX = Math.round(tarPlayer.getLocation().getBlockX() - .5) + .5;
                     double playerY = tarPlayer.getLocation().getBlockY();
                     double playerZ = Math.round(tarPlayer.getLocation().getBlockZ() - .5) + .5;
@@ -66,16 +72,20 @@ public class Glacius extends Spell {
                     };
 
                     final Location top = tarPlayer.getLocation().add(0, 2, 0);
-                    blocks.put(top, top.getBlock().getType());
-                    top.getBlock().setType(Material.ICE);
-
+                    if(!(top.getBlock().getState() instanceof InventoryHolder)) {
+                    	blocks.put(top, top.getBlock().getType());
+                        top.getBlock().setType(Material.ICE);
+                    }
+                    
                     for (Location locs : locations) {
                         for (BlockFace bf : surroundings) {
 
                             final Block relative = locs.getBlock().getRelative(bf, 1);
 
-                            blocks.put(relative.getLocation(), relative.getType());
-                            relative.setType(Material.ICE);
+                            if(!(relative.getState() instanceof InventoryHolder)) {
+                            	blocks.put(relative.getLocation(), relative.getType());
+                                relative.setType(Material.ICE);
+                            }
 
                         }
 
@@ -88,15 +98,19 @@ public class Glacius extends Spell {
                                 for (BlockFace bf : surroundings) {
                                     final Block relative = locs.getBlock().getRelative(bf, 1);
 
-                                    relative.setType(blocks.get(relative.getLocation()));
-                                    blocks.remove(relative.getLocation());
+                                    if(blocks.containsKey(relative.getLocation())) {
+	                                    relative.setType(blocks.get(relative.getLocation()));
+	                                    blocks.remove(relative.getLocation());
+                                    }
 
                                 }
 
                             }
 
-                            top.getBlock().setType(blocks.get(top));
-                            blocks.remove(top);
+                            if(blocks.containsKey(top)) {
+	                            top.getBlock().setType(blocks.get(top));
+	                            blocks.remove(top);
+                            }
 
                         }
 

--- a/src/com/hpspells/core/util/BlockUtils.java
+++ b/src/com/hpspells/core/util/BlockUtils.java
@@ -10,6 +10,7 @@ import org.bukkit.Material;
 import org.bukkit.Tag;
 import org.bukkit.block.Block;
 import org.bukkit.block.BlockFace;
+import org.bukkit.block.data.Bisected;
 import org.bukkit.block.data.type.Door;
 import org.bukkit.block.data.type.Door.Hinge;
 
@@ -136,6 +137,15 @@ public final class BlockUtils {
 			}
 		}
 		return null;
+	}
+
+	/**
+	 * Gets the other part (top or bottom half) of the door
+	 * @param block Block that is part of a door
+	 * @return The block above or block below which is part of the same door
+	 */
+	public static Block getOtherDoorPartBlock(Block block) {
+		return ((Bisected) block.getBlockData()).getHalf() == Bisected.Half.TOP ? block.getRelative(BlockFace.DOWN) : block.getRelative(BlockFace.UP);
 	}
 
 }

--- a/src/com/hpspells/core/util/MiscUtilities.java
+++ b/src/com/hpspells/core/util/MiscUtilities.java
@@ -1,63 +1,53 @@
 package com.hpspells.core.util;
 
+import org.bukkit.enchantments.Enchantment;
+import org.bukkit.inventory.ItemFlag;
 import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
 
 import java.util.Map;
 import java.util.Random;
-
-import static com.hpspells.core.util.SVPBypass.getMethod;
 
 /**
  * A class containing a mix of effects
  */
 public class MiscUtilities {
-    private static Class<?> cbItemStack = SVPBypass.getCurrentCBClass("inventory.CraftItemStack"), nmsItemStack = SVPBypass.getCurrentNMSClass("ItemStack"), nmsTagCompound = SVPBypass.getCurrentNMSClass("NBTTagCompound"), nmsTagList = SVPBypass.getCurrentNMSClass("NBTTagList");
+
+    private static Enchantment glowEnchant = Enchantment.LURE;
 
     /**
      * Makes an {@link ItemStack} glow as if enchanted <br>
-     * Based on stirante's {@code addGlow} method in his <a href="https://github.com/SocialCraft/PrettyScaryLib/blob/master/src/com/stirante/PrettyScaryLib/EnchantGlow.java">EnchantGlow</a> class
+     * Used to be based on stirante's {@code addGlow} method in his <a href="https://github.com/SocialCraft/PrettyScaryLib/blob/master/src/com/stirante/PrettyScaryLib/EnchantGlow.java">EnchantGlow</a> class
+     * but now just uses a hidden LURE enchantment.
      *
      * @param item the item stack to make glow
      * @return the glowing item stack
      * @throws Exception if an error occurred whilst making the item glow
      */
     public static ItemStack makeGlow(ItemStack item) throws Exception {
-        Object nmsStack = getMethod(cbItemStack, "asNMSCopy").invoke(cbItemStack, item);
-        Object tag = null;
-
-        if (!((Boolean) getMethod(nmsItemStack, "hasTag").invoke(nmsStack))) {
-            tag = nmsTagCompound.newInstance();
-            getMethod(nmsItemStack, "setTag").invoke(nmsStack, tag);
-        }
-
-        if (tag == null)
-            tag = getMethod(nmsItemStack, "getTag").invoke(nmsStack);
-
-        Object ench = nmsTagList.newInstance();
-        getMethod(nmsTagCompound, "set").invoke(tag, "ench", ench);
-        getMethod(nmsItemStack, "setTag").invoke(nmsStack, tag);
-        return (ItemStack) getMethod(cbItemStack, "asCraftMirror").invoke(cbItemStack, nmsStack);
+        ItemMeta meta = item.getItemMeta();
+        // Replace below with meta.setEnchantmentGlintOverride(true); when migrated to spigot 1.20.5 and above
+        meta.addEnchant(glowEnchant, 1, true);
+        meta.addItemFlags(ItemFlag.HIDE_ENCHANTS);
+        item.setItemMeta(meta);
+        return item;
     }
 
     /**
      * Makes an {@link ItemStack} stop glowing as if enchanted <br>
-     * Based on stirante's {@code removeGlow} method in his <a href="https://github.com/SocialCraft/PrettyScaryLib/blob/master/src/com/stirante/PrettyScaryLib/EnchantGlow.java">EnchantGlow</a> class
+     * Used to be based on stirante's {@code removeGlow} method in his <a href="https://github.com/SocialCraft/PrettyScaryLib/blob/master/src/com/stirante/PrettyScaryLib/EnchantGlow.java">EnchantGlow</a> class
+     * but now just removes the LURE enchantment
      *
      * @param item the item stack to make stop glowing
      * @return the non-glowing item stack
-     * @throws Exception if an error occurred whilst making the item glow
      */
-    public static ItemStack stopGlow(ItemStack item) throws Exception {
-        Object nmsStack = getMethod(cbItemStack, "asNMSCopy").invoke(cbItemStack, item);
-        Object tag = null;
-
-        if (!((Boolean) getMethod(nmsItemStack, "hasTag").invoke(nmsStack)))
-            return item;
-
-        tag = getMethod(nmsItemStack, "getTag").invoke(nmsStack);
-        getMethod(nmsTagCompound, "set").invoke(tag, "ench", null);
-        getMethod(nmsItemStack, "setTag").invoke(nmsStack, tag);
-        return (ItemStack) getMethod(cbItemStack, "asCraftMirror").invoke(cbItemStack, nmsStack);
+    public static ItemStack stopGlow(ItemStack item) {
+        ItemMeta meta = item.getItemMeta();
+        // Replace below with meta.setEnchantmentGlintOverride(false); when migrated to spigot 1.20.5 and above
+        if (meta.removeEnchant(glowEnchant)) {
+            item.setItemMeta(meta);
+        }
+        return item;
     }
 
     /**

--- a/src/config.yml
+++ b/src/config.yml
@@ -5,6 +5,10 @@ messaging:
   info: 'YELLOW'
   warning: 'RED'
 
+disabledWorlds:
+  - world1
+  - world2
+
 wand:
   # The material types of the wand
   # Note: Only the first one will be craftable the rest you can only get by using the /wand command

--- a/src/cz-czech.properties
+++ b/src/cz-czech.properties
@@ -1,0 +1,177 @@
+######################################################
+#      HarryPotterSpells Language File - Czech       #
+######################################################
+
+###########
+# General #
+###########
+
+genPluginEnabled = Plugin zapnut.
+genPluginDisabled = Plugin vypnut.
+genKnowNoSpells = Neumíte žádné kouzla.
+genSpellNotRecognized = Toto kouzlo nebylo rozpoznáno.
+
+# Help
+hlpDescription = Harry Potter plugin
+
+# Command
+cmdUnknown = Neznámý příkaz. Napište \"%shelp\" pro nápovědu.
+cmdUsage = Správné použití: %s%s
+cmdNoPermission = Nemáte práva pro použití tohoto příkazu.
+cmdPlayerOnly = Tento příkaz může použít pouze hráč.
+cmdPlayerNotFound = Hráč nebyl nalezen.
+cmdPlayerNotSpecified = Prosím, specifikujte hráče.
+cmdUnknownConfigPaths = Nenalezen soubor s nastavením, prosím zkontrolujte zadanou cestu.
+cmdUnknownConfigTypes = Špatný typ konfigurace. Možné typy jsou [default, spell, cooldown]
+
+# Custom Configuration
+ccnCouldNotSave = Nepodařilo se uložit konfigurační soubor do %s.
+
+# PlayerSpellConfig
+pscOutOfDate = PlayerSpellConfig.yml není aktuální! Aktualizuji soubor...
+pscUpdated = PlayerSpellConfig.yml byl aktualizován na verzi %s.
+
+# PM
+pmSpellSelected = Vybral(a) jste kouzlo: %s.
+pmSpellCast = Použili jste kouzlo %s!
+
+# Cooldown
+cldWait = Musíte počkat %s sekund před znovu provedením kouzla.
+
+# Errors
+errCommandMap = Nelze získat přístup k mapě příkazů. Příkazy nebudou fungovat.
+errSpells = Došlo k chybě s přidávaním kouzla %s do seznamu. Toto kouzlo nebude k dispozici. 
+errPluginMetrics = Při povolení Plugin Metrics došlo k chybě.
+errAddCommandMapAnnotation = Příkaz %s nelze přidat do mapy příkazů. Chybí anotace @HCommand
+errAddCommandMap = Nelze přidat příkaz %s do mapy příkazů.
+errFireworkEffect = Při generování efektu Firework došlo k chybě!
+errParticleEffect = Při generování Particle efektu došlo k chybě!
+errEnchantmentEffect = Při generování efektu Enchantment došlo k chybě!
+errCraftingChanges = Nelze přidat recept na tvorbu hůlky. Zkontrolujte config.yml
+errReflectionsReplacementCmd = Při registraci minimálně jednoho příkazu došlo k chybě.
+errReflectionsReplacementSpelll = Při registraci minimálně jednoho kouzla došlo k chybě.
+errExtensionLoading = Při načítání rozšíření ze souboru %s došlo k chybě.
+errWandCreationInvalidType = Typ materiálu pro hůlku %s nebyl zadán nebo je neplatný,
+errPluginReload = Plugin byl nahrán s chybami!
+
+# Extensions
+extMissingDescription = Nelze načíst zoršíření z %s . Chybí soubor s popisem.
+extCouldNotCreateConfig = Nelze vytvořit výchozí konfiguraci pro rozšíření %s
+extCouldNotSaveConfig = Konfiguraci pro rozšíření %s nelze uložit.
+
+# Debug
+dbgLanguageLoaded = Načtený jazykový soubor %s
+dbgRegisteredCoreCommands = Základní příkazy %s byly zaregistrovány.
+dbgHelpCommandsAdded = Příkazy byly přidány do nápovědy.
+dbgCraftingStart = Spouštění změn craftingu...
+dbgCraftingEnd = Změny craftingu byly dokončeny.
+dbgExtensionStart = Spouštění správce rozšíření...
+dbgExtensionStop = Správce rozšíření byl spuštěn.
+
+############
+# Commands #
+############
+
+# General Command
+cmdGenDescription = Příkaz pro ovládání pluginu.
+cmdGenConfigReloaded = Nastavení úšpěšně načteno.
+cmdGenConfigUpdated = Nastavení bylo úspěšně aktualizováno.
+cmdGenConfigSpellUpdated = Nastavení bylo úspěšně aktualizováno.
+cmdGenConfigCooldownUpdated = Nastavení bylo úspěšně aktualizováno.
+cmdGenPluginReloaded = Plugin byl úspěšně načten.
+
+# Spell Info
+cmdSpiDescription = Zobrazí popis kouzla.
+
+# Spell List
+cmdSplDescription = Vypíše všechny kouzla
+cmdSplKnown = Naučená kouzla:
+cmdSplNoneKnown = %s nezná žádné kouzla.
+cmdSplPlayerKnows = Kouzla, které %s zná:
+
+# Spell Switch
+cmdSpsDescription = Změní aktuální kouzlo na požadované
+cmdSpsPlayerDoesntKnow = Toto kouzlo jste se nenaučili
+
+# Teach
+cmdTeaDescription = Naučí hráče kouzlo
+cmdTeaTaught = Naučil(a) jste %s kouzla:
+cmdTeaTaughtOne = Naučil(a) jste %s kouzlo %s.
+cmdTeaKnowsAll = %s již umí všechny kouzla.
+cmdTeaKnowsThat = %s tohle kouzo umí.
+cmdTeaCantTeach = Nemůžeš naučit %s %s když nevíš, jak to udělat.
+
+# Unteach
+cmdUntDescription = Hráč zapomene kouzlo
+cmdUntForgot = %s zapomněl kouzla:
+cmdUntForgotOne = %s zapomněl kouzlo %s.
+cmdUntDoesntKnowAll = %s neumí žádné kouzlo.
+cmdUntDoesntKnowOne = %s neumí kouzlo %s.
+
+# Wand
+cmdWanDescription = Přičaruje kouzelníkovi hůlku.
+cmdWanGiven = Dostali jste hůlku!
+cmdWanGifted = %s od vás obdržel/a hůlku.
+cmdWanOffline = %s není online.
+
+##########
+# Spells #
+##########
+
+spellBlockOnly = Toto kouzlo může být použito pouze na blok.
+spellLivingEntityOrSelf = Toto kouzlo může být použito pouze na sebe, jiného hráče nebo příšeru.
+spellLivingEntityOnly = Tohle kouzlo může být použito pouze na jiného hráče nebo příšeru.
+spellPlayerOnly = Tohle kouzlo může být použito pouze na jiného hráče.
+spellNoRose =  Na tomto bloku nemůže růst růže.
+spellEarthOnly = Toto kouzlo může být použito pouze na blok hlíny nebo trávy.
+spellNoTree = Zde nemůžete zasadit strom.
+spellUnauthorized = Nemáte práva používat nebo naučit toto kouzlo.
+
+# Descriptions
+descAccio = Přitáhné okolní itemy ke kouzelníkovi
+descAguamenti = Umístí vodu ná namířený blok
+descAlarteAscendare = Zvedne cílené příšery do vzduchu
+descAlohomora = Odemkne železné dveře na které míříte
+descAparecium = Zviditelní hráče
+descAraniaExumai = Zraňuje a posouvá pavouky zpět
+descArrow = Vystřelí z hůlky šíp
+descAvadaKedavra = Zabije cíl
+descAvis = Vystřelí z hůlky hejno kuřat
+descBauleo = Způsobí, že všechny blízké předměty budou uloženy do nejbližší bedny
+descBubbleHeadCharm = Obnoví kyslík cíli do plna
+descColloportus = Zamkne dveře na zadaný čas
+descConfringo = Vystřelí ohnivou kouli ze špičky kouzelníkovy hůlky
+descConfundo = Zmate cíl
+descCrucio = Mučí oběť
+descDeprimo = Zpomalí cíl
+descDuro = Přemění blok v kámen
+descEnderChest = Otevře vaši ender bednu
+descEpiskey = Pomalu léčí váš cíl
+descEvanesco = Zneviditelní kouzelníka
+descExpelliarmus = Odzbrojí váš cíl
+descFiniteIncantatem = Odstraní z cíle efekt kouzla Petrificus Totalus a lektvarů
+descFlameFreezingCharm = Pokytne účinek ohnivzdorného lektvaru na zadanou dobu
+descGlacius = Zmrazí cíl
+descHomenumRevelio = Odhalí hráče okolo kouzelníka
+descIncendio = Lights the targeted mob or block on fire
+descLegilimens = Ukáže kouzelníkovi inventář hráče, na kterého použil toto kouzlo
+descMagnaTonitrus = Vystřelí blesk
+descMorsmordre = Vytvoří na obloze znamení zla
+descMulticorfors = Změní barvu vlny nebo ovce na kterou míříte
+descObscuro = Oslepí váš cíl
+descOrchideous = Zasadí červenou růži na namířeném bloku
+descPetrificusTotalus = Omráčí cílového hráče
+descPointMe = Otočí hráče k severu
+descReducto = Vytvoří explozi
+descRefillingCharm = Naplní misku hřibovou polévkou, kyblík vodou nebo mlékem (lze zvolit v nastavení)
+descReparo = Zcela opraví item, který držíte v ruce
+descSectumsempra = Pomalu zraňuje váš cíl
+descSilencio = Umlčí hráče na zadaný čas
+descSonorus = Další zprávu uvidí celý svět
+descSpongify = Zabraňuje zranění pádem
+descStupefy = Omráčí váš cíl
+descTime = Přepíná čas v závislosti na cílovém bloku
+descTree = Vytvoří strom z bloku, na který míříte
+descWeather = Ukončí stávající cyklus počasí
+descWingardiumLeviosa = Umožní kouzelníkovi na krátký čas vzletět, kouzlo se preruší jiným kouzlem
+descWorkbench = Otevře pracovní stůl

--- a/src/es-spanish.properties
+++ b/src/es-spanish.properties
@@ -6,162 +6,171 @@
 # General #
 ###########
 
-genPluginEnabled = Activar plugin.
-genPluginDisabled = Desactivar plugin.
-genKnowNoSpells = No conoces ningún hechizo.
-genSpellNotRecognized = Ese hechizo no pudo encontrar.
+genPluginEnabled = Plugin activado.
+genPluginDisabled = Plugin desactivado.
+genKnowNoSpells = Todavía no conoces ningún hechizo.
+genSpellNotRecognized = No reconozco ese hechizo.
 
 # Help
-hlpDescription = El mejor plugin de Harry Potter
+hlpDescription = El nuevo plugin de Harry Potter.
 
 # Command
-cmdUnknown = Comando desconocido. Escribe \"%shelp\" para abrir el panel de ayuda.
-cmdUsage = Corregir uso: %s%s
-cmdNoPermission = No tienes permiso de usar ese comando.
-cmdPlayerOnly = Necesitas ser un jugador para utilizar ese comando.
-cmdPlayerNotFound = Ese jugador no pudo ser encontrado.
-cmdPlayerNotSpecified = Por favor, especifique el jugador.
+cmdUnknown = Comando desconocido. Escribe \"%shelp\" para ayuda.
+cmdUsage = Uso correcto: %s%s
+cmdNoPermission = No tienes permiso para ejecutar ese comando.
+cmdPlayerOnly = Necesitas ser un jugador para ejecutar ese comando.
+cmdPlayerNotFound = No se ha podido encontrar a ese jugador.
+cmdPlayerNotSpecified = Por favor, especifica un jugador.
+cmdUnknownConfigPaths = Ruta de configuración desconocida, por favor verifique de nuevo y vuelva a intentarlo.
+cmdUnknownConfigTypes = Tipo de configuración incorrecto. Posibles tipos de configuración: [default, spell, cooldown]
 
 # Custom Configuration
-ccnCouldNotSave = No se pudo salvar la configuración a %s.
+ccnCouldNotSave = No se pudo guardar la configuración para %s.
 
 # PlayerSpellConfig
-pscOutOfDate = El PlayerSpellConfig.yml se encuentra desactualizado! Actualizando archivo...
-pscUpdated = El PlayerSpellConfig.yml ha sido actualizado a la versión %s.
+pscOutOfDate = El archivo PlayerSpellConfig.yml está desactualizado! Actualizando archivo...
+pscUpdated = El archivo PlayerSpellConfig.yml ha sido actualizado a la versión %s.
 
 # PM
 pmSpellSelected = Has seleccionado el hechizo: %s.
-pmSpellCast = Has conjurado %s!
+pmSpellCast = Has utilizado %s!
 
 # Cooldown
-cldWait = Deberás esperar %s segundos antes de volver a conjurar este hechizo.
+cldWait = Necesitas esperar %s segundos antes de utilizar ese hechizo de nuevo.
 
 # Errors
-errCommandMap = No se pudo acceder a los comandos del mapa. Los comandos no funcionarán.
-errSpells = Un error ha ocurrido mientras se añadía el hechizo %s a la lista de hechizos. El hechizo no estará disponible.
-errPluginMetrics = Un error ha ocurrido mientras se activaba el Plugin Metrics
-errAddCommandMapAnnotation = No se pudo añadir el comando %s a los comandos del mapa. Le falta la anotación @HCommand.
-errAddCommandMap = No se pudo añadir el comando %s a los comandos del mapa.
-errFireworkEffect = Un error ocurrió mientras se generaba el efecto de Fuegos artificiales!
-errParticleEffect = Un error ocurrió mientras se generaba el efecto de Partículas!
-errEnchantmentEffect = Un error ocurrió mientras se generaba el efecto de Encantamientos!
-errCraftingChanges = No se pudo añadir una receta a tu varita. ¿Está el archivo config.yml correcto?
-errReflectionsReplacementCmd = Un error ocurrió mientras registraba alguno(os) de los comandos.
-errReflectionsReplacementSpelll = n error ocurrió mientras registraba alguno(os) de los hechizos.
-errExtensionLoading = Un error ocurrió mientras se cargaba la extensión del archivo %s.
-errWandCreationInvalidType = El material de la Varita %s fue inválido o no especificado.
+errCommandMap = No se pudo acceder al mapa de comandos. Los comandos no funcionarán.
+errSpells = Se produjo un error al agregar el hechizo %s a la lista de hechizos. Ese hechizo no estará disponible.
+errPluginMetrics = Se produjo un error al habilitar las métricas del plugin.
+errAddCommandMapAnnotation = No se pudo agregar el comando %s al mapa de comandos. Falta la anotación @HCommand.
+errAddCommandMap = No se pudo agregar el comando %s al mapa de comandos.
+errFireworkEffect = Se produjo un error al generar un efecto de fuegos artificiales!
+errParticleEffect = Se produjo un error al generar un efecto de partículas!
+errEnchantmentEffect = Se produjo un error al generar un efecto de encantamiento!
+errCraftingChanges = No se pudo agregar la receta de elaboración para la varita. ¿Es correcto el archivo config.yml?
+errReflectionsReplacementCmd = Ocurrió un error al registrar algunos/todos los comandos.
+errReflectionsReplacementSpelll = Ocurrió un error al registrar algunos/todos los hechizos.
+errExtensionLoading = Ocurrió un error al cargar la extensión del archivo %s.
+errWandCreationInvalidType = El tipo de material para la varita %s no se especificó o no es válido.
+errPluginReload = Complemento recargado con errores!
 
 # Extensions
-extMissingDescription = No se pudo cargar la extensión desde %s ya que le falta el archivo de descripción.
-extCouldNotCreateConfig = No se pudo crear una confuguración por default de la extensión %s.
+extMissingDescription = No se pudo cargar la extensión de %s porque falta un archivo de descripción.
+extCouldNotCreateConfig = No se pudo crear la configuración predeterminada para la extensión %s.
+extCouldNotSaveConfig = No se pudo guardar la configuración para la extensión %s
 
 # Debug
-dbgLanguageLoaded = El archivo del lenguaje %s ha sido cargado.
-dbgRegisteredCoreCommands = Los comandos  %s han sido registrados.
-dbgHelpCommandsAdded = Se añadieron los comandos para ayudar.
-dbgCraftingStart = Comenzando la modificación de creación...
-dbgCraftingEnd = Modificación de creación finalizada.
-dbgExtensionStart = Comenzando la gestión de extensiones...
-dbgExtensionStop = Gestión de extensiones comenzada.
+dbgLanguageLoaded = Archivo de idioma cargado %s correctamente.
+dbgRegisteredCoreCommands = Comandos centrales de %s registrados.
+dbgHelpCommandsAdded = Comandos agregados para el comando de ayuda (/help).
+dbgCraftingStart = Iniciando modificación de creación ...
+dbgCraftingEnd = Modificaciones de fabricación completas.
+dbgExtensionStart = Iniciando Extension Manager ...
+dbgExtensionStop = Se inició el Administrador de extensiones.
 
 ############
 # Commands #
 ############
 
 # General Command
-cmdGenDescription = Comando para manejar algunos aspectos del plugin en el juego.
-cmdGenConfigReloaded = Has reiniciado todas las configuraciones.
-cmdGenConfigUpdated = Configuración correctamente mejorada.
-cmdGenConfigSpellUpdated = Configuración correctamente mejorada.
-cmdGenConfigCooldownUpdated = Configuración correctamente mejorada.
+cmdGenDescription = Comando para controlar algunos aspectos del plugin en el juego.
+cmdGenConfigReloaded = Recargó correctamente todas las configuraciones.
+cmdGenConfigUpdated = La configuración se actualizó correctamente.
+cmdGenConfigSpellUpdated = Configuración actualizada correctamente.
+cmdGenConfigCooldownUpdated = Configuración actualizada correctamente.
+cmdGenPluginReloaded = Complemento recargado correctamente.
 
-# Spell Info
-cmdSpiDescription = Muestra la descripción de un hechizo.
+# Información de hechizo
+cmdSpiDescription = Muestra la descripción de un hechizo
 
-# Spell List
-cmdSplDescription = Lista de los hechizos
+# Lista de hechizos
+cmdSplDescription = Lista de todos los hechizos
 cmdSplKnown = Hechizos que conoces:
 cmdSplNoneKnown = %s no conoce ningún hechizo.
 cmdSplPlayerKnows = Hechizos que %s conoce:
 
-# Spell Switch
-cmdSpsDescription = Cambia el hechizo actual al hechizo deseado.
-cmdSpsPlayerDoesntKnow = No has aprendido ese hechizo todavía
+# Interruptor de hechizo
+cmdSpsDescription = Cambia el hechizo actual al deseado.
+cmdSpsPlayerDoesntKnow = Aún no has aprendido este hechizo!
 
-# Teach
-cmdTeaDescription = Enseña a un jugador un hechizo
+# Enseñar
+cmdTeaDescription = Enseña a un jugador un hechizo determinado
 cmdTeaTaught = Le has enseñado a %s los hechizos:
 cmdTeaTaughtOne = Le has enseñado a %s el hechizo %s.
-cmdTeaKnowsAll = %s ya conoce todos los hechizos.
-cmdTeaKnowsThat = %s ya sabe ese hechizo.
-cmdTeaCantTeach = No le puedes enseñar a %s %s ya que no lo conoces.
+cmdTeaKnowsAll = %s ya conoce todos los hechizos! Es un gran mago...
+cmdTeaKnowsThat = %s ya conoce ese hechizo.
+cmdTeaCantTeach = No puede enseñar %s %s porque no lo sabe.
 
 # Unteach
-cmdUntDescription = Hace que un jugador olvide el hechizo
+cmdUntDescription = Haz que un jugador olvide un hechizo.
 cmdUntForgot = %s ha olvidado los hechizos:
-cmdUntForgotOne = %s ha olvidado %s.
-cmdUntDoesntKnowAll = %s no sabe ningún hechizo.
+cmdUntForgotOne = %s ha olvidado el hechizo %s.
+cmdUntDoesntKnowAll = %s no conoce ningún hechizo.
 cmdUntDoesntKnowOne = %s no conoce el hechizo %s.
 
-# Wand
-cmdWanDescription = Cede una varita
-cmdWanGiven = ¡Has cedido una varita!
-cmdWanGifted = %s ha recibido una varita de ti.
-cmdWanOffline = %s no se encuentra en línea.
+# Varita
+cmdWanDescription = Convoca al remitente una varita
+cmdWanGiven = Te han dado una varita!
+cmdWanGifted = %s ha recibido tu varita!
+cmdWanOffline = ERROR El jugador %s no está en línea.
 
 ##########
 # Spells #
 ##########
 
-spellBlockOnly = Este hechizo sólo puede ser aplicado a un bloque.
-spellLivingEntityOrSelf = Este hechizo sólo puede ser utilizado en ti mismo, otro jugador, o un mob.
-spellLivingEntityOnly = Este hechizo sólo puede ser utilizado en un jugador o un mob.
-spellPlayerOnly = Este hechizo sólo puede ser utilizado en un jugador.
-spellNoRose = ¡No puedes hacer crecer eso!
-spellEarthOnly = Este hechizo sólo puede ser utilizado en un bloque de césped o tierra.
-spellNoTree = ¡No puedes hacer crecer eso!
-spellUnauthorized = No tienes permiso para utilizar ese hechizo.
+spellBlockOnly = Este hechizo solo se puede utilizar con bloques
+spellLivingEntityOrSelf = Este hechizo solo se puede utilizar en ti mismo, en otro jugador o en una criatura.
+spellLivingEntityOnly = Este hechizo solo se puede usar en un jugador o en una criatura.
+spellPlayerOnly = Este hechizo solo se puede usar en un jugador.
+spellNoRose = No puedes colocar una rosa en ese bloque.
+spellEarthOnly = Esto solo se puede usar en un bloque de césped o tierra.
+spellNoTree = No puede colocar un árbol aquí.
+spellUnauthorized = No tienes permiso para utilizar / enseñar este hechizo
 
-# Descriptions
-descAccio = Acerca objetos tirados hacia ti
-descAguamenti = Coloca agua en el bloque seleccionado.
-descAlarteAscendare = Lanza al mob objetivo por los aires
-descAlohomora = Desbloquea una puerta cerrada con llave
-descAparecium = Hace jugadores cercanos visibles
-descAraniaExumai = Daña y expulsa arañas hacia atrás
-descAvadaKedavra = Mata al objetivo
-descAvis = ¡Lanza gallinas por los aires!
-descBauleo = Guarda los objetos caídos en un cofre cercano
-descBubbleHeadCharm = Crea una burbuja que permite respirar bajo el agua
-descConfringo = ¡Cuidado con el fuego! Lanza una bola de fuego de la punta de tu varita
-descConfundo = ¿Quién soy? ¡Confunde a tu enemigo!
-descCrucio = Tortura a tu objetivo
-descDeprimo = Hace a tu objetivo lento cual caracol
-descEnderChest = Abre tu bolsa con fondo ampliado
-descEpiskey = Cura las heridas de tu objetivo
-descEvanesco = Me ves; ahora ya no me ves. Hace invisible al mago que lo conjure.
-descExpelliarmus = Desarma a tu oponente.
-descFiniteIncantatem = Quita todo efecto que tenga el objetivo
-descFlameFreezingCharm = Caminante entre llamas. Obten resistencia al fuego por un tiempo
-descGlacius = Congela a tu objetivo
-descHomenumRevelio = Revela la ubicación de alguien cercano
-descIncendio = Ilumina a un mob objetivo, en un bloque lo prende en fuego
-descLegilimens = Enseña al mago los bolsillos del objetivo
-descMagnaTonitrus = ¿Impoctrueno? Lanza un rayo desde la punta de tu varita
-descMorsmordre = Conjura el símbolo de los Mortífagos en el cielo
-descMulticorfors = ¡Lanza tinta por la varita! Cambia el color de lana u oveja
-descObscuro = Vuelve el mundo oscuro para tu objetivo
-descOrchideous = Hace crecer una rosa de la tierra
-descPetrificusTotalus = Petrifica al objetivo
+# Descripciones
+descAccio = Atrae a los items cercanos hacia ti
+descAguamenti = Genera agua en un bloque determinado
+descAlarteAscendare = Impulsa a una criatura hacia arriba
+descAlohomora = Abre una puerta de hierro sin botones ni palancas
+descAparecium = Hace visibles a los jugadores cercanos
+descAraniaExumai = Daña a las arañas
+descArrow = Dispara una flecha con la varita
+descAvadaKedavra = Mata a un jugador o una criatura con un solo lanzamiento
+descAvis = Dispara a una bandada de pollos con tu varita
+descBauleo = Haz que todos los items cercanos se almacenen en un cofre cercano
+descBubbleHeadCharm = Rellena la barra de aire de un jugador al máximo
+descColloportus = Bloquea una puerta durante un tiempo determinado
+descConfringo = Lanza una bola de fuego desde tu varita
+descConfundo = Confunde a tu adversario
+descCrucio = Tortura a tu víctima
+descDeprimo = Ralentiza a tu objetivo casi hasta detenerse
+descDuro = Convierte un bloque en piedra
+descEnderChest = Abre tu cofre del end personal
+descEpiskey = Cura lentamente a un jugador
+descEvanesco = Hace que el lanzador sea invisible
+descExpelliarmus = Desarma a tu adversario
+descFiniteIncantatem = Elimina los efectos de las pociones y despetrifica a un jugador determinado
+descFlameFreezingCharm = Se otorga un efecto de poción de resistencia al fuego durante un período de tiempo determinado
+descGlacius = Encierra al objetivo en un gran bloque de hielo
+descHomenumRevelio = Revela a los jugadores cercanos a ti
+descIncendio = Incendia un bloque o una criatura
+descLegilimens = Muestra el inventario de otro jugador
+descMagnaTonitrus = Dispara un rayo
+descMorsmordre = Conjura la marca de los mortífagos en el cielo
+descMulticorfors = Cambia el color de cualquier lana u oveja
+descObscuro = Ciega a una criatura o a un jugador
+descOrchideous = Planta una rosa roja en el bloque objetivo
+descPetrificusTotalus = Aturde a tu adversario
+descPointMe = Establece la vista del jugador hacia el norte
 descReducto = Crea una explosión
-descRefillingCharm = ¿Quieres más? Rellena tu plato/cubo con lo que especifiques
-descReparo = Repara un objeto (aumentando su durabilidad)
-descSectumsempra = Daña lentamente a tu objetivo
-descSilencio = Silencia a un jugador por un tiempo
-descSonorus = Emite el sonido que esté junto a ti a todo el servidor
+descRefillingCharm = Rellena tazones con sopa de champiñones, o cubos con agua o leche (definido en la configuración)
+descReparo = Repara completamente un item de tu mano
+descSectumsempra = Daña lentamente a tu adversario
+descSilencio = Silencia al jugador durante un tiempo determinado
+descSonorus = Transmite lo que grites a todo el servidor
 descSpongify = Evita el daño por caída
 descStupefy = Aturde al objetivo
-descTime = Cambia el tiempo dependiendo de tu bloque objetivo
-descTree = Hace crecer un árbol de la tierra
+descTime = Cambia el tiempo usandolo con un bloque
+descTree = Genera un árbol
 descWingardiumLeviosa = Hace que el mago levite por un corto periodo de tiempo o hasta el siguiente hechizo
 descWorkbench = ¿Mesa de trabajo en el rellano? ¿Por qué no mejor en tu mano?

--- a/src/kr-korean.properties
+++ b/src/kr-korean.properties
@@ -1,0 +1,174 @@
+######################################################
+#       HarryPotterSpells Language File - 한글        #
+######################################################
+
+###########
+# General #
+###########
+
+genPluginEnabled = 플러그인이 활성화되었습니다.
+genPluginDisabled = 플러그인이 비활성화되었습니다.
+genKnowNoSpells = 당신은 어떠한 주문도 배우지 않았습니다.
+genSpellNotRecognized = 그 주문은 인식되지 않습니다.
+
+# Help
+hlpDescription = 최고의 해리 포터 플러그인입니다.
+
+# Command
+cmdUnknown = 알 수 없는 명령어입니다. 도움말을 보려면 \"%shelp\"를 입력하세요.
+cmdUsage = 올바른 사용법: %s%s
+cmdNoPermission = 이 명령어를 실행할 권한이 없습니다.
+cmdPlayerOnly = 이 명령어는 플레이어만 사용할 수 있습니다.
+cmdPlayerNotFound = 해당 플레이어를 찾을 수 없습니다.
+cmdPlayerNotSpecified = 플레이어를 지정해주세요.
+cmdUnknownConfigPaths = 알 수 없는 구성 경로입니다. 다시 확인해보세요.
+cmdUnknownConfigTypes = 잘못된 구성 유형입니다. 가능한 구성 유형: [default, spell, cooldown]
+
+# Custom Configuration
+ccnCouldNotSave = %s에 구성을 저장할 수 없습니다.
+
+# PlayerSpellConfig
+pscOutOfDate = PlayerSpellConfig.yml이 오래되었습니다! 파일을 업데이트 중입니다...
+pscUpdated = PlayerSpellConfig.yml이 버전 %s으로 업데이트되었습니다.
+
+# PM
+pmSpellSelected = 당신은 %s 주문을 선택했습니다.
+pmSpellCast = %s 주문을 시전했습니다!
+
+# Cooldown
+cldWait = 이 주문을 다시 시전하기 전에 %s초를 기다려야 합니다.
+
+# Errors
+errCommandMap = 명령어 맵에 접근할 수 없습니다. 명령어가 작동하지 않습니다.
+errSpells = 주문 목록에 %s 주문을 추가하는 중 오류가 발생했습니다. 해당 주문은 사용할 수 없습니다.
+errPluginMetrics = 플러그인 메트릭을 활성화하는 중 오류가 발생했습니다.
+errAddCommandMapAnnotation = @HCommand 어노테이션이 누락되어 명령어 %s을(를) 명령어 맵에 추가할 수 없습니다.
+errAddCommandMap = 명령어 %s을(를) 명령어 맵에 추가할 수 없습니다.
+errFireworkEffect = 폭죽 이펙트를 생성하는 중 오류가 발생했습니다!
+errParticleEffect = 파티클 이펙트를 생성하는 중 오류가 발생했습니다!
+errEnchantmentEffect = 마법 부여 이펙트를 생성하는 중 오류가 발생했습니다!
+errCraftingChanges = 완드 제작용 조합법을 추가할 수 없습니다. config.yml
+
+# Extensions
+extMissingDescription = %s 확장자를 설명 파일이 없어서 불러올 수 없습니다.
+extCouldNotCreateConfig = %s 확장자의 기본 구성을 만들 수 없습니다.
+extCouldNotSaveConfig = %s 확장자 구성을 저장할 수 없습니다.
+
+# Debug
+dbgLanguageLoaded = 언어 파일 %s이(가) 로드되었습니다.
+dbgRegisteredCoreCommands = 핵심 명령어 %s개를 등록했습니다.
+dbgHelpCommandsAdded = 도움말 명령어가 추가되었습니다.
+dbgCraftingStart = 조합 수정 시작...
+dbgCraftingEnd = 조합 수정이 완료되었습니다.
+dbgExtensionStart = 확장자 관리자 시작...
+dbgExtensionStop = 확장자 관리자가 시작되었습니다.
+
+############
+# Commands #
+############
+
+# General Command
+cmdGenDescription = 플러그인의 일부 기능을 게임 내에서 제어하는 명령어
+cmdGenConfigReloaded = 모든 구성 요소가 성공적으로 다시 로드되었습니다.
+cmdGenConfigUpdated = 구성 요소가 성공적으로 업데이트되었습니다.
+cmdGenConfigSpellUpdated = 구성 요소가 성공적으로 업데이트되었습니다.
+cmdGenConfigCooldownUpdated = 구성 요소가 성공적으로 업데이트되었습니다.
+cmdGenPluginReloaded = 플러그인이 성공적으로 다시 로드되었습니다.
+
+# Spell Info
+cmdSpiDescription = 주문 설명을 보여주는 명령어
+
+# Spell List
+cmdSplDescription = 모든 주문을 나열하는 명령어
+cmdSplKnown = 알고 있는 주문:
+cmdSplNoneKnown = %s은(는) 어떤 주문도 알지 못합니다.
+cmdSplPlayerKnows = %s이(가) 알고 있는 주문:
+
+# Spell Switch
+cmdSpsDescription = 현재 주문을 원하는 주문으로 변경하는 명령어
+cmdSpsPlayerDoesntKnow = 이 주문을 아직 배우지 않았습니다.
+
+# Teach
+cmdTeaDescription = 플레이어에게 주문을 가르치는 명령어
+cmdTeaTaught = %s에게 주문을 가르쳤습니다.
+cmdTeaTaughtOne = %s에게 %s 주문을 가르쳤습니다.
+cmdTeaKnowsAll = %s은(는) 이미 모든 주문을 알고 있습니다.
+cmdTeaKnowsThat = %s은(는) 이미 그 주문을 알고 있습니다.
+cmdTeaCantTeach = %s에게 %s 주문을 가르칠 수 없습니다. 이 주문을 배우지 않았기 때문입니다.
+
+# Unteach
+cmdUntDescription = 플레이어가 주문을 잊게합니다
+cmdUntForgot = %s님이 주문을 잊었습니다.
+cmdUntForgotOne = %s님이 %s 주문을 잊었습니다.
+cmdUntDoesntKnowAll = %s님은 주문을 모르고 있습니다.
+cmdUntDoesntKnowOne = %s님이 %s 주문을 모르고 있습니다.
+
+# Wand
+cmdWanDescription = 발신자에게 마법봉을 소환합니다
+cmdWanGiven = 마법봉을 받았습니다!
+cmdWanGifted = %s님이 마법봉을 받았습니다.
+cmdWanOffline = %s님이 오프라인입니다.
+
+##########
+# Spells #
+##########
+
+spellBlockOnly = 블록에만 사용할 수 있습니다.
+spellLivingEntityOrSelf = 자신, 다른 플레이어 또는 몹에만 사용할 수 있습니다.
+spellLivingEntityOnly = 플레이어 또는 몹에만 사용할 수 있습니다.
+spellPlayerOnly = 플레이어에게만 사용할 수 있습니다.
+spellNoRose = 그 블록에는 장미를 놓을 수 없습니다.
+spellEarthOnly = 잔디나 흙 블록에만 사용할 수 있습니다.
+spellNoTree = 이곳에 나무를 심을 수 없습니다.
+spellUnauthorized = 이 주문을 시전/가르칠 권한이 없습니다.
+
+# Descriptions
+descAccio = 주변 아이템을 당겨줍니다.
+descAguamenti = 대상 블록에 물을 생성합니다.
+descAlarteAscendare = 대상 몹을 위쪽으로 밀어올립니다.
+descAlohomora = 대상 철문을 열어줍니다.
+descAparecium = 근처의 플레이어를 표시합니다.
+descAraniaExumai = 거미를 공격해 넉백시킵니다.
+descArrow = 완드에서 화살을 발사합니다.
+descAvadaKedavra = 대상을 죽입니다.
+descAvis = 완드에서 닭 떼를 발사합니다.
+descBauleo = 근처의 모든 아이템을 가까운 상자에 보관합니다.
+descBubbleHeadCharm = 대상 플레이어의 공기 게이지를 모두 채워줍니다.
+descColloportus = 문을 일정 시간 동안 잠급니다.
+descConfringo = 완드에서 불덩이를 발사합니다.
+descConfundo = 대상을 혼란스럽게 만듭니다.
+descCrucio = 대상을 고통스럽게 합니다.
+descDeprimo = 대상을 거의 멈춰버릴 정도로 느리게 합니다.
+descDuro = 블록을 돌로 바꿉니다.
+descEnderChest = 개인 엔더 상자를 엽니다.
+descEpiskey = 대상의 체력을 천천히 회복시킵니다.
+descEvanesco = 시전자를 투명하게 만듭니다.
+descExpectoPatronum = 위더 스켈레톤에게 데미지를 줍니다.
+descExpelliarmus = 대상의 무기를 제거합니다.
+descFiniteIncantatem = 대상 플레이어의 포션 효과를 제거하고 돌아오게 합니다.
+descFlameFreezingCharm = 일정 시간 동안 자신에게 화염 저항 효과를 줍니다.
+descFlipendo = 대상 몹을 밀어냅니다.
+descGlacius = 대상을 얼립니다.
+descHomenumRevelio = 시전자 주변의 플레이어를 보여줍니다.
+descIncendio = 대상 몹이나 블록에 불을 붙입니다.
+descLegilimens = 시전자에게 대상 플레이어의 인벤토리를 보여줍니다.
+descMagnaTonitrus = 벼락을 발사합니다.
+descMorsmordre = 대기 중에 죽음의 신봉자 상징을 소환합니다.
+descMulticorfors = 대상 양털이나 양의 색을 변경합니다.
+descObscuro = 대상 몹 또는 플레이어의 시야를 가립니다.
+descOrchideous = 대상 블록에 빨간색 장미를 심습니다.
+descPetrificusTotalus = 대상 플레이어를 기절시킵니다.
+descPointMe = 플레이어의 시선을 북쪽으로 설정합니다.
+descReducto = 폭발을 일으킵니다.
+descRefillingCharm = 그릇에 버섯 수프를 채우거나, 물 또는 우유를 채우는 마법입니다(설정에서 정의).
+descReparo = 손에 들고 있는 아이템을 완전히 수리합니다.
+descSectumsempra = 대상 플레이어에게 천천히 피해를 입힙니다.
+descSilencio = 일정 시간 동안 플레이어를 음소거합니다.
+descSonorus = 다음 대화 내용을 전체 서버에 브로드캐스트합니다.
+descSpongify = 낙하 대미지를 방지합니다.
+descStupefy = 대상을 기절시킵니다.
+descTime = 대상 블록에 따라 시간을 전환합니다.
+descTree = 대상 블록에서 나무를 생성합니다.
+descWeather = 현재 날씨 주기를 종료합니다.
+descWingardiumLeviosa = 캐스터가 잠시나마 비행할 수 있게 합니다.
+descWorkbench = 모든 곳에서 제작대를 엽니다.

--- a/src/no-norwegian.properties
+++ b/src/no-norwegian.properties
@@ -1,0 +1,177 @@
+######################################################
+#    HarryPotterSpells Language File - Norwegian     #
+######################################################
+
+###########
+# General #
+###########
+
+genPluginEnabled = Plugin aktivert.
+genPluginDisabled = Plugin deaktivert.
+genKnowNoSpells = Du kjenner ingen trollformler.
+genSpellNotRecognized = Den trollformlen ble ikke gjenkjent.
+
+# Help
+hlpDescription = Den ultimate Harry Potter plugin
+
+# Command
+cmdUnknown = Ukjent kommando. Skriv \ "%shelp \" for hjelp.
+cmdUsage = Riktig bruk er: %s%s
+cmdNoPermission = Du har ikke tillatelse til å kjøre den kommandoen.
+cmdPlayerOnly =Du må være en spiller for å bruke denne kommandoen.
+cmdPlayerNotFound = Den spilleren ble ikke funnet.
+cmdPlayerNotSpecified = Vennligst spesifiser en spiller.
+cmdUnknownConfigPaths = Ukjent konfigurasjons bane, dobbelt sjekk og prøv igjen.
+cmdUnknownConfigTypes = Feil konfigurasjonstype. Mulige konfigurasjons typer: [standard, spell, cooldown]
+
+# Custom Configuration
+ccnCouldNotSave = Kunne ikke lagre konfigurasjonen til %s.
+
+# PlayerSpellConfig
+pscOutOfDate = PlayerSpellConfig.yml er utdatert! OppdaterOppdater filer...
+pscUpdated = The PlayerSpellConfig.yml er oppdatert til versjon %s.
+
+# PM
+pmSpellSelected = Du har valgt trylleformel: %s.
+pmSpellCast = Du har brukt trylleformel: %s!
+
+# Cooldown
+cldWait = Du må vente %s sekunder før du utfører denne trylleformel igjen.
+
+# Errors
+errCommandMap = Kunne ikke få tilgang til kommando kartet. Kommandoer fungerer ikke.
+errSpells = Det oppstod en feil under tilføyelse av %s trylleformel til trylleformel listen. Den trylleformel vil ikke være tilgjengelig.
+errPluginMetrics = Det oppstod en feil under aktivering av plugin metrics.
+errAddCommandMapAnnotation = Kunne ikke legge til kommando %s på kommandokartet. Det mangler @H kommand merknad.
+errAddCommandMap = Kunne ikke legge til kommando %s på kommando kartet.
+errFireworkEffect =Det oppstod en feil under generering av fyrverkerieffekt!
+errParticleEffect = Det oppstod en feil under generering av en partikkel effekt!
+errEnchantmentEffect = Det oppstod en feil under generering av en Enchantment Effekt!
+errCraftingChanges = Kunne ikke legge til lagingsoppskrift på stav. Er config.yml filen riktig?
+errReflectionsReplacementCmd = Det oppstod en feil under registreringen av noen/alle kommandoene.
+errReflectionsReplacementSpelll = Det oppstod en feil under registreringen av noen / alle trollformler.
+errExtensionLoading = Det oppstod en feil under lasting av utvidelsen fra filen %s.
+errWandCreationInvalidType = Materialtype for stav %s var enten ikke spesifisert eller ugyldig.
+errPluginReload = Plugin er lastet på nytt med feil!
+
+# Extensions
+extMissingDescription = Kunne ikke laste utvidelse fra %s da det mangler en beskrivelsesfil.
+extCouldNotCreateConfig = Kunne ikke opprette standardkonfigurasjon for utvidelse %s.
+extCouldNotSaveConfig = Kunne ikke lagre konfigurasjonen for utvidelse %s
+
+# Debug
+dbgLanguageLoaded = Lastet språkfil %s
+dbgRegisteredCoreCommands = Registrerte %s kjernekommandoer.
+dbgHelpCommandsAdded = Lagt til kommandoer for å help
+dbgCraftingStart = Begynner å lage krafting endringer ...
+dbgCraftingEnd = Endring av krafting fullført
+dbgExtensionStart = Starter utvidelse Manager...
+dbgExtensionStop = utvidelse Manager startet.
+
+############
+# Commands #
+############
+
+# General Command
+cmdGenDescription = Kommando for å kontrollere noen aspekter av plugin-in-game
+cmdGenConfigReloaded = Lastet inn alle konfigurasjonene på nytt.
+cmdGenConfigUpdated = Konfigurasjonen ble oppdatert.
+cmdGenConfigSpellUpdated = Konfigurasjonen ble oppdatert.
+cmdGenConfigCooldownUpdated = Konfigurasjonen ble oppdatert.
+cmdGenPluginReloaded = Plugin lastet på nytt.
+
+# Spell Info
+cmdSpiDescription = Viser beskrivelsen av en trylleformel
+
+# Spell List
+cmdSplDescription = Lista over alle trylleformel
+cmdSplKnown = trylleformel du veit om:
+cmdSplNoneKnown = %s kjenner ingen trylleformel.
+cmdSplPlayerKnows = trylleformel %s vet:
+
+# Spell Switch
+cmdSpsDescription = Endrer gjeldende trolldom til ønsket
+cmdSpsPlayerDoesntKnow = Du har ikke lært denne trolldommen ennå
+
+# Teach
+cmdTeaDescription = Lærer en spiller en trollformel
+cmdTeaTaught =Du har lært %s ein trollformel:
+cmdTeaTaughtOne = Du har lært %s trollformelen %s.
+cmdTeaKnowsAll = %s kjenner allerede alle trollformel.
+cmdTeaKnowsThat = %s vet allerede den trollformel.
+cmdTeaCantTeach = Du kan ikke lære %s %s fordi du ikke vet det.
+
+# Unteach
+cmdUntDescription = Gjør at en spiller glemmer en trollformler
+cmdUntForgot = %s har glemt trollformler:
+cmdUntForgotOne = %s har glemt %s.
+cmdUntDoesntKnowAll = %s kjenner ingen trollformler.
+cmdUntDoesntKnowOne = %s vet ikke %s.
+
+# Wand
+cmdWanDescription = Innkaller avsenderen til et tryllestav
+cmdWanGiven = Du har fått en tryllestav!
+cmdWanGifted = %s har mottatt en tryllestav fra deg.
+cmdWanOffline = %s er ikke online.
+
+##########
+# Spells #
+##########
+
+spellBlockOnly = Dette kan bare brukes på blokker.
+spellLivingEntityOrSelf = Dette kan bare brukes på deg selv, en annen spiller eller et monster.
+spellLivingEntityOnly = Dette kan bare brukes på en spiller eller et monster.
+spellPlayerOnly =Dette kan bare brukes på en spiller.
+spellNoRose = Du kan ikke plassere en rose på den blokka.
+spellEarthOnly = Dette kan bare brukes på en gress eller jord blokker.
+¨'ellNoTree = Du kan ikke plassere et tre her
+spellUnauthorized = Du har ikke tillatelse til å bruke eller lære denne trylleformularen
+
+# Descriptions
+descAccio = Trekker omkringliggende drops mot deg
+descAguamenti = Plasser vann i mål blokken
+descAlarteAscendare = Driv den målrettede monster oppover
+descAlohomora = Låser opp den målrettede jerndøren
+descAparecium = Synliggjør spillere i nærheten
+descAraniaExumai = Skader og banker ned edderkopper
+descArrow = Skyter en pil ut av tryllestaven
+descAvadaKedavra = Dreper hvem som er målrettet
+descAvis = Skyter en flokk kyllinger fra tryllestaven din
+descBauleo = Forårsaker at alle gjenstander som er falt ned, blir lagret i et nærliggende kister
+descBubbleHeadCharm = Påfyll målspillerens luftbobler heilt fullt
+descColloportus = Låser dører i en bestemt tidsperiode
+descConfringo = Skyter en ildkule fra tuppen av tryllestaven din
+descConfundo = Forvirrer målet ditt
+descCrucio = Torturere ditt offer
+descDeprimo = Bremser målet ditt nesten
+descDuro = Gjør en blokk til stein
+descEnderChest = Åpner din personlige enderchest
+descEpiskey = Leger sakte målet ditt
+descEvanesco = Gjør bruker usynlig
+descExpelliarmus = Avvæpner målet ditt
+descFiniteIncantatem = Fjerner potioneffekter og unpetrifies mål spilleren
+descFlameFreezingCharm =Gir selv FireResistance-potion-effekt i en bestemt tidsperiode
+descGlacius = Innkapsler målet i is
+descHomenumRevelio = Avslører spillere i nærheten av bruker
+descIncendio = Lyser den målrettede mobben eller blokkerer i brann
+descLegilimens = Viser caster målspillerens inventory
+descMagnaTonitrus = Skyter en ball av lyn
+descMorsmordre = Viser symbolet på dødsspiserne på himmelen
+descMulticorfors = Endrer fargen på målrettet ull eller sau
+descObscuro = blinder mål monster eller spilleren
+descOrchideous = Planter en rød rose på mål blokken
+descPetrificusTotalus = Stuner målet
+descPointMe = Angir spillerens utsikt mot nord
+descReducto = Skaper en eksplosjon
+descRefillingCharm = Påfyll boller med soppsuppe, bøtter med vann eller melk (definert i config)
+descReparo = Reparerer gjennstand i hånden din helt
+descSectumsempra = Skader mål spilleren sakte
+descSilencio = Demper spilleren i en bestemt tidsperiode
+descSonorus = Sender hva du enn roper til hele serveren
+descSpongify = Forhindrer fallskade
+descStupefy = Stuner målet
+descTime = Veksler mellom tiden avhengig av målblokken
+descTree = Produserer et tre fra målblokken
+descWeather = Avslutter gjeldende værsyklus
+descWingardiumLeviosa = Får hjulet til å fly en kort stund eller til neste kast
+descWorkbench = Åpner et kraftingbord hvor som helst

--- a/src/plugin.yml
+++ b/src/plugin.yml
@@ -2,4 +2,4 @@ name: HarryPotterSpells
 main: com.hpspells.core.HPS
 prefix: "HPS"
 version: 1.2.4 BETA
-api-version: 1.13
+api-version: 1.20

--- a/src/plugin.yml
+++ b/src/plugin.yml
@@ -1,5 +1,5 @@
 name: HarryPotterSpells
 main: com.hpspells.core.HPS
 prefix: "HPS"
-version: 1.2.4 BETA
+version: 1.3.0 BETA
 api-version: 1.20


### PR DESCRIPTION
Changelog:
HPS now requires Minecraft 1.20+ and Java 17+ in order to support all new materials/features

Additions:
* Update `api-version` from `1.13` to `1.20` in order to support new Materials of doors/buttons and to use new APIs introduced throughout the minecraft versions
* Add `Other Contributions` section in README for translations
* Add `kr-korean`, `cz-czech` and `no-norwegian` language support
* Update `es-spanish` translation
* Update bStats `Metrics.java` class to version `3.1.0`
* Add config option to disable HPS on specific worlds
* Update buttons to include:
  * `BAMBOO_BUTTON`
  * `CHERRY_BUTTON`
  * `CRIMSON_BUTTON`
  * `MANGROVE_BUTTON`
  * `POLISHED_BLACKSTONE_BUTTON`
  * `WARPED_BUTTON`
* Update doors to include:
  * `BAMBOO_DOOR`
  * `CHERRY_DOOR`
  * `CRIMSON_DOOR`
  * `MANGROVE_DOOR`
  * `WARPED_DOOR`
* Update pressure plates to include:
  * `BAMBOO_PRESSURE_PLATE`
  * `CHERRY_PRESSURE_PLATE`
  * `CRIMSON_PRESSURE_PLATE`
  * `MANGROVE_PRESSURE_PLATE`
  * `POLISHED_BLACKSTONE_PRESSURE_PLATE`
  * `WARPED_PRESSURE_PLATE`

Issues:
* Fix message colors for `newSpell` and `notify` in PluginMessenger
* Fix spelling of `Language.getLanuage` to `Language.getLanguage`
* Register commands using reflection on `getServer` instead of NMS with CraftBukkit Server
  * This broke for Paper since 1.20.5 due to CraftBukkit code being moved
* Fix issue where craftable spell receipes were no longer registering
* Fix issue where wand no longer glowed
* Replace commons-lang 'Validate' with google guava 'Precondition' with 1.20 API migration
* Fix issue where Colloportus and Alohomora wasn't working on new doors

Spells:
* Colloportus: Now has `CRIMSON_SPORE` particle effect instead of `BARRIER`
* Glacius: Add protection feature to prevent breaking blocks that are storages